### PR TITLE
refactor: allow for profiles-dir argument and change handle test assumptions

### DIFF
--- a/dbt_sugar/core/clients/dbt.py
+++ b/dbt_sugar/core/clients/dbt.py
@@ -1,7 +1,7 @@
 """Holds methods to interact with dbt API and objects."""
 
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic import BaseModel, root_validator
 
@@ -63,7 +63,7 @@ class DbtProfile:
         self._profiles_dir = profiles_dir
 
         # attrs populated by class methods
-        self.profile: Optional[DbtProfilesModel] = None
+        self.profile: Optional[Dict[str, str]] = None
 
     @property
     def profiles_dir(self):

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -27,6 +27,8 @@ class FlagParser:
         self.traceback_stack_depth: int = 4
         self.sugar_cane: str = str()
         self.config_path: Path = Path(str())
+        self.profiles_dir: Path = Path(str())
+        self.is_dry_run: bool = False
 
     def consume_cli_arguments(self, test_cli_args: List[str] = list()) -> None:
         if test_cli_args:
@@ -42,10 +44,13 @@ class FlagParser:
             self.log_level = self.args.log_level
             self.full_tracebacks = self.args.full_tracebacks
             self.sugar_cane = self.args.sugar_cane
+            self.is_dry_run = self.args.dry_run
+            if self.args.profiles_dir:
+                self.profiles_dir = Path(self.args.profiles_dir).expanduser()
             if self.args.config_path:
                 self.config_path = Path(self.args.config_path).expanduser()
-            else:
-                self.config_path = Path()
+            # else:
+            # self.config_path = Path()
 
         # task specific args consumption
         if self.task == "doc":

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -49,8 +49,6 @@ class FlagParser:
                 self.profiles_dir = Path(self.args.profiles_dir).expanduser()
             if self.args.config_path:
                 self.config_path = Path(self.args.config_path).expanduser()
-            # else:
-            # self.config_path = Path()
 
         # task specific args consumption
         if self.task == "doc":

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -1,11 +1,13 @@
 """Main module for dbt-sugar. Sets up CLI arguments and sets up task handlers."""
 import argparse
 import sys
-from typing import List
+from typing import List, Union
 
 from dbt_sugar.core._version import __version__
 from dbt_sugar.core.flags import FlagParser
+from dbt_sugar.core.logger import GLOBAL_LOGGER as logger
 from dbt_sugar.core.logger import log_manager
+from dbt_sugar.core.task.base import BaseTask
 from dbt_sugar.core.task.doc import DocumentationTask
 from dbt_sugar.core.utils import check_and_compare_version
 
@@ -55,6 +57,9 @@ base_subparser.add_argument(
 base_subparser.add_argument(
     "--config-path", help="Full path to config.yml file if not using default."
 )
+base_subparser.add_argument(
+    "--profiles-dir", help="Alternative path to the dbt profiles.yml file.", type=str, default=str()
+)
 
 # Task-specific argument sub parsers
 sub_parsers = parser.add_subparsers(title="Available dbt-sugar commands", dest="command")
@@ -70,10 +75,19 @@ document_sub_parser.add_argument(
 document_sub_parser.add_argument(
     "-s", "--schema", help="database schema where the model is.", type=str, default=None
 )
+document_sub_parser.add_argument(
+    "--dry-run",
+    help="When provided the documentation task will not modify your files",
+    action="store_true",
+    default=False,
+)
 
 
 # task handler
-def handle(parser: argparse.ArgumentParser, test_cli_args: List[str] = list()) -> None:
+def handle(
+    parser: argparse.ArgumentParser,
+    test_cli_args: List[str] = list(),
+) -> Union[int, BaseTask]:
     """Task handler factory.
 
     Args:
@@ -87,6 +101,12 @@ def handle(parser: argparse.ArgumentParser, test_cli_args: List[str] = list()) -
 
     if flag_parser.task == "doc":
         task: DocumentationTask = DocumentationTask(flag_parser)
+        # TODO: We actually need to change the behaviour of DocumentationTask to provide an interactive
+        # dry run but for not this allows testing without side effects.
+        # the current implementation upsets mypy also.
+        if flag_parser.is_dry_run:
+            logger.warning("Running in --dry-run mode no files will be modified")
+            return task
         return task.run()
 
     raise NotImplementedError(f"{flag_parser.task} is not supported.")
@@ -94,6 +114,7 @@ def handle(parser: argparse.ArgumentParser, test_cli_args: List[str] = list()) -
 
 def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()) -> int:
     """Just your boring main."""
+    exit_code = 0
     _cli_args = list()
     if test_cli_args:
         _cli_args = test_cli_args
@@ -103,6 +124,7 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
         version_message = check_and_print_version()
         print(version_message)
         print("\n")
+        # TODO: Update this when a proper dry-run exists.
+        exit_code = handle(parser, _cli_args)  # type: ignore
 
-        handle(parser, _cli_args)
-    return 0
+    exit(exit_code)

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -102,7 +102,7 @@ def handle(
     if flag_parser.task == "doc":
         task: DocumentationTask = DocumentationTask(flag_parser)
         # TODO: We actually need to change the behaviour of DocumentationTask to provide an interactive
-        # dry run but for not this allows testing without side effects.
+        # dry run but for now this allows testing without side effects.
         # the current implementation upsets mypy also.
         if flag_parser.is_dry_run:
             logger.warning("Running in --dry-run mode no files will be modified")

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -85,6 +85,6 @@ class BaseTask(abc.ABC):
         return False
 
     @abc.abstractmethod
-    def run(self) -> None:
+    def run(self) -> int:
         """Orchestrator method that calls all the needed stuff to run a documentation task."""
         ...

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -20,13 +20,12 @@ class DocumentationTask(BaseTask):
 
     def __init__(self, flags: FlagParser) -> None:
         super().__init__()
-        self.flags = flags
+        self._flags = flags
 
     def load_dbt_credentials(self) -> Dict[str, str]:
         """Method to load the DBT profile credentials."""
         dbt_profile = DbtProfile(
-            project_name="default",
-            target_name="dev",
+            project_name="default", target_name="dev", profiles_dir=self._flags.profiles_dir
         )
         dbt_profile.read_profile()
         dbt_credentials = dbt_profile.profile
@@ -35,12 +34,12 @@ class DocumentationTask(BaseTask):
             exit(1)
         return dbt_credentials
 
-    def run(self) -> None:
+    def run(self) -> int:
         """Main script to run the command doc"""
         columns_sql = []
 
-        model = self.flags.model
-        schema = self.flags.schema
+        model = self._flags.model
+        schema = self._flags.schema
 
         dbt_credentials = self.load_dbt_credentials()
         type_of_connection = dbt_credentials.get("type", "")
@@ -61,6 +60,7 @@ class DocumentationTask(BaseTask):
             ).get_columns_from_table(model, schema)
 
         self.process_model(model, columns_sql)
+        return 0
 
     def update_model(
         self, content: Dict[str, Any], model_name: str, columns_sql: List[str]

--- a/tests/docker_postgres/profiles.yml
+++ b/tests/docker_postgres/profiles.yml
@@ -1,3 +1,19 @@
+default:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      user: dbt_sugar_test_user
+      # TODO: Refactor `DbtProfile` to expect different field keys.
+      # ! somehow their profiles aren't consistently keyed...
+      # https://docs.getdbt.com/reference/warehouse-profiles/postgres-profile/
+      password: magical_password
+      port: 5432
+      database: dbt_sugar
+      schema: public
+      threads: 4
+
 dbt_sugar_test:
   target: dev
   outputs:

--- a/tests/handle_test.py
+++ b/tests/handle_test.py
@@ -1,13 +1,30 @@
 import pytest
+from pathlib import Path
+
+from dbt_sugar.core.task.doc import DocumentationTask
+
+TEST_PROFILES_DIR = Path(__file__).parent.joinpath("docker_postgres", "profiles.yml")
 
 
 @pytest.mark.parametrize(
     "cli_args",
-    [["doc", "-m", "test_model"], ["doc", "-m", "test_model", "--log-level", "debug"]],
+    [
+        ["doc", "-m", "test_model", "--profiles-dir", str(TEST_PROFILES_DIR), "--dry-run"],
+        [
+            "doc",
+            "-m",
+            "test_model",
+            "--log-level",
+            "debug",
+            "--profiles-dir",
+            str(TEST_PROFILES_DIR),
+            "--dry-run",
+        ],
+    ],
 )
 def test_handle(cli_args):
     from dbt_sugar.core.main import handle, parser
 
     handle_result = handle(parser, test_cli_args=cli_args)
 
-    assert handle_result == 0
+    assert isinstance(handle_result, DocumentationTask)


### PR DESCRIPTION
# Description
- In order to test profiles in CI we need to allow for a `--profile-dir` argument to be passed. This is now done.
- I also updated the behaviour and expectation of the unit test for `handle()` since we don't want it to run any of the documentation task. This might be something we revisit more cleanly later it's a bit "dirty" but it will get us there.

# How was the change tested
Unit tests are now passing locally