### PR TITLE
refactor: rename all references to sugar cane and cane to syrup

### DIFF
--- a/changelog/39.feature.rst
+++ b/changelog/39.feature.rst
@@ -1,0 +1,1 @@
+The concept of ``sugar_cane`` is renamed to ``syrup`` to avoid historically loaded interpretations.

--- a/dbt_sugar/core/exceptions.py
+++ b/dbt_sugar/core/exceptions.py
@@ -23,12 +23,12 @@ class ProfileParsingError(DbtSugarException):
     """Thrown when no target entry could be found."""
 
 
-class SugarCaneNotFoundError(DbtSugarException):
-    """Thrown when a sugar cane config could not be extracted from the config.yaml."""
+class SyrupNotFoundError(DbtSugarException):
+    """Thrown when a syrup config could not be extracted from the config.yaml."""
 
 
-class NoSugarCaneProvided(DbtSugarException):
-    """Thrown when neither a default sugar_cane nor a cli-passed sugar cane can be found."""
+class NoSyrupProvided(DbtSugarException):
+    """Thrown when neither a default syrup nor a cli-passed syrup can be found."""
 
 
 class MissingDbtProjects(DbtSugarException):

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -24,7 +24,7 @@ class FlagParser:
         self.model: str = "test_model"
         self.log_level: str = "debug"
         self.traceback_stack_depth: int = 4
-        self.sugar_cane: str = str()
+        self.syrup: str = str()
         self.config_path: Path = Path(str())
 
     def consume_cli_arguments(self, test_cli_args: List[str] = list()) -> None:
@@ -40,7 +40,7 @@ class FlagParser:
         if self.args:
             self.log_level = self.args.log_level
             self.full_tracebacks = self.args.full_tracebacks
-            self.sugar_cane = self.args.sugar_cane
+            self.syrup = self.args.syrup
             if self.args.config_path:
                 self.config_path = Path(self.args.config_path).expanduser()
             else:

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -45,9 +45,8 @@ base_subparser.add_argument(
     default=False,
 )
 base_subparser.add_argument(
-    "-c",
-    "--sugar-cane",
-    help="Name of the sugar cane confi you wish to use. If left empty dbt-sugar will attempt to read your defaults.",
+    "--syrup",
+    help="Name of the syrup confi you wish to use. If left empty dbt-sugar will attempt to read your defaults.",
     type=str,
     default=str(),
 )

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -38,22 +38,22 @@ def test_Config(cli_args, test_desc):
 
 
 @pytest.mark.parametrize(
-    "has_no_default_cane, is_missing_cane, is_missing_dbt_project",
+    "has_no_default_syrup, is_missing_syrup, is_missing_dbt_project",
     [(False, False, False), (True, False, False), (False, True, False), (False, False, True)],
 )
 @pytest.mark.datafiles(FIXTURE_DIR)
-def test_load_config(datafiles, has_no_default_cane, is_missing_cane, is_missing_dbt_project):
+def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missing_dbt_project):
     from dbt_sugar.core.main import parser
     from dbt_sugar.core.flags import FlagParser
     from dbt_sugar.core.config.config import DbtSugarConfig
     from dbt_sugar.core.exceptions import (
-        SugarCaneNotFoundError,
-        NoSugarCaneProvided,
+        SyrupNotFoundError,
+        NoSyrupProvided,
         MissingDbtProjects,
     )
 
     expectation = {
-        "name": "cane_1",
+        "name": "syrup_1",
         "dbt_projects": [
             {
                 "name": "dbt_sugar_test",
@@ -64,15 +64,15 @@ def test_load_config(datafiles, has_no_default_cane, is_missing_cane, is_missing
     }
 
     config_filepath = Path(datafiles).joinpath("sugar_config.yml")
-    if has_no_default_cane:
+    if has_no_default_syrup:
         config_filepath = Path(datafiles).joinpath("sugar_config_missing_default.yml")
 
-    if is_missing_cane:
-        cli_args = ["doc", "--config-path", str(config_filepath), "--sugar-cane", "non_existant"]
-    elif has_no_default_cane:
+    if is_missing_syrup:
+        cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "non_existant"]
+    elif has_no_default_syrup:
         cli_args = ["doc", "--config-path", str(config_filepath)]
     elif is_missing_dbt_project:
-        cli_args = ["doc", "--config-path", str(config_filepath), "--sugar-cane", "cane_2"]
+        cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "syrup_2"]
     else:
         cli_args = ["doc", "--config-path", str(config_filepath)]
 
@@ -80,11 +80,11 @@ def test_load_config(datafiles, has_no_default_cane, is_missing_cane, is_missing
     flags.consume_cli_arguments(cli_args)
 
     config = DbtSugarConfig(flags)
-    if is_missing_cane:
-        with pytest.raises(SugarCaneNotFoundError):
+    if is_missing_syrup:
+        with pytest.raises(SyrupNotFoundError):
             config.load_config()
-    elif has_no_default_cane:
-        with pytest.raises(NoSugarCaneProvided):
+    elif has_no_default_syrup:
+        with pytest.raises(NoSyrupProvided):
             config.load_config()
     elif is_missing_dbt_project:
         with pytest.raises(MissingDbtProjects):

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -1,14 +1,14 @@
 defaults:
-  sugar_cane: cane_1
+  syrup: syrup_1
   target: dev
-sugar_canes:
-  - name: cane_1
+syrups:
+  - name: syrup_1
     dbt_projects:
       - name: dbt_sugar_test
         path: "./tests/test_dbt_project/dbt_sugar_test"
         excluded_tables:
           - table_a
-  - name: cane_2
+  - name: syrup_2
     dbt_projects:
       - name: dwh
         path: path

--- a/tests/sugar_config_missing_default.yml
+++ b/tests/sugar_config_missing_default.yml
@@ -1,13 +1,13 @@
 defaults:
   target: dev
-sugar_canes:
-  - name: cane_1
+syrups:
+  - name: syrup_1
     dbt_projects:
       - name: dwh
         path: path
         excluded_tables:
           - table_a
-  - name: cane_2
+  - name: syrup_2
     dbt_projects:
       - name: dwh
         path: path


### PR DESCRIPTION
# Description
Sugar cane could be a bit loaded as a reference so I'm turning to a less loaded concept called `syrup` it's also sweeter 🍬 

# How was the change tested
unit tests are running locally.

# Issue Information
Closes #35 

# Checklist
- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
