### PR TITLE
feat: :lipstick: implement Documentation CLI UI

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party =luddite,packaging,pretty_errors,pydantic,pytest,snowflake,sqlalchemy,yaml
+known_third_party =luddite,packaging,pretty_errors,pydantic,pytest,questionary,snowflake,sqlalchemy,yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: isort
         name: Sort import with isort
         args: ["-m3", "-w 100", "--tc"]
-        exclude: ^tests/
+        # exclude: ^tests/
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: "v2.2.1"
     hooks:

--- a/changelog/46.feature.rst
+++ b/changelog/46.feature.rst
@@ -1,0 +1,4 @@
+``dbt-sugar`` now offers the following UI/Front-End Flow:
+- model-level description writing
+- column-level description witing (only undocumented columns for now)
+  - user can choose to document **all undocumented columns in one go** or **select a subset of columns to document**

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,5 +3,5 @@ coverage:
     project:
       default:
         threshold: 3%
-        target: 80%
+        target: 70%
     patch: off

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -70,10 +70,14 @@ document_sub_parser = sub_parsers.add_parser(
 )
 document_sub_parser.set_defaults(cls=DocumentationTask, which="doc")
 document_sub_parser.add_argument(
-    "-m", "--model", help="dbt model name to document", type=str, default=None
+    "-m", "--model", help="Name of the dbt model to document", type=str, default=None
 )
 document_sub_parser.add_argument(
-    "-s", "--schema", help="database schema where the model is.", type=str, default=None
+    "-s",
+    "--schema",
+    help="Name of the database schema in which the model resides",
+    type=str,
+    default=None,
 )
 document_sub_parser.add_argument(
     "--dry-run",
@@ -129,7 +133,7 @@ def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = li
         version_message = check_and_print_version()
         print(version_message)
         print("\n")
-        # TODO: Update this when a proper dry-run exists.
-        exit_code = handle(parser, _cli_args)  # type: ignore
+    # TODO: Update this when a proper dry-run exists.
+    exit_code = handle(parser, _cli_args)  # type: ignore
 
     exit(exit_code)

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -1,0 +1,229 @@
+"""User Input Collector API."""
+
+from typing import Any, Dict, List, Mapping, Union
+
+import questionary
+from pydantic import BaseModel, validator
+
+DESCRIPTION_PROMPT_MESSAGE = "Please write down your description:"
+
+
+class ConfirmQuestion(BaseModel):
+    """Validation model for a question confirmation type payload."""
+
+    type: str
+    message: str
+    name: str
+    qmark: str = "?"
+    auto_enter: bool = True
+
+    @validator("type")
+    def check_type_is_confirm(cls, value):
+        assert value == "confirm", "'type' must be set to 'confirm' for this question type."
+        return value
+
+
+class ConfirmModelDoc(ConfirmQuestion):
+    """Validatiorn model for a model documentation specific confirm question.
+
+    Extends ConfirmQuestion to add stricter validation on the name field.
+    """
+
+    @validator("name")
+    def check_name_is_wants_to_document(cls, value):
+        assert (
+            value == "wants_to_document_model"
+        ), "'name' must be set to 'wants_to_document_model'."
+        return value
+
+
+class FreeTextInput(BaseModel):
+    """Validation model for a free text input question payload."""
+
+    type: str
+    name: str
+    message: str
+
+    @validator("type")
+    def check_type_is_text(cls, value):
+        assert value == "text", "'type' must be set to 'text' for this question type."
+        return value
+
+
+class DescriptionTextInput(FreeTextInput):
+    """Validation model for a model or column description text question payload.
+
+    Extends FreeTextInput to add a stricter message validation.
+    """
+
+    message: str = DESCRIPTION_PROMPT_MESSAGE
+
+    @validator("message")
+    def check_message_text(cls, value):
+        assert (
+            value == DESCRIPTION_PROMPT_MESSAGE
+        ), "Overriding question prompt is not allowed for a description question"
+        return value
+
+
+class MultipleChoiceInput(BaseModel):
+    """Validation model for a multiple choice question payload."""
+
+    type: str
+    choices: List[str]
+    name: str
+
+    @validator("type")
+    def check_type_is_choice(cls, value):
+        assert value == "checkbox", "'type' must be set to checkbox."
+        return value
+
+    @validator("name")
+    def check_name_is_cols_to_document(cls, value):
+        assert value == "cols_to_document", "'name' must be set to 'cols_to_document'."
+        return value
+
+
+class UserInputCollector:
+    """User input collector class.
+
+    Validates and orchestrates the interface between the dbt-sugar back end and the questionary API.
+    Uses questionary API for CLI collection and imposes some stronger validation rules or flows.
+
+    MAINTENANCE: When we add a lot more question types, we'll likely want to refactor this class to
+    use a factory as the view code is going to get long and full of ifs. For now this should get us
+    started in the right direction.
+    """
+
+    def __init__(self, question_type: str, question_payload: List[Mapping[str, Any]]) -> None:
+        """Constructor for UserInpurCollector.
+
+        Expects a question type and a question payload. The payload must be a list of dictionaries,
+        following the `questionary.prompt()` API.
+
+        Args:
+            question_type (str): name of the questioning flow type.
+                Currently supported: ['model', 'undocumented_cols'].
+            question_payload (List[Mapping[str, Any]]): List of dicts following the
+                `questionary.prompt()` API requirements (examples below):
+                    https://questionary.readthedocs.io/en/stable/pages/advanced.html#question-dictionaries
+
+        Question Payload Examples:
+        ```python
+        model_doc_payload = [
+            {
+                "type": "confirm",
+                "name": "wants_to_document_model",
+                "message": "Model Description: This is my previously documented model. Document?",
+                "default": True,
+            },
+            {
+                "type": "text",
+                "name": "model_description",
+                "message": "Please write down your description:"
+            },
+        ]
+
+        undocumented_columns_payload = [
+            {
+                "type": "checkbox",
+                "name": "cols_to_document",
+                "choices": ["col_a", "col_b"],
+                "message": "Select the columns you want to document.",
+            }
+        ]
+        ```
+        """
+        self._question_type = question_type
+        self._question_payload = question_payload
+        self._is_valid_question_payload = False
+
+    def _validate_question_payload(self) -> None:
+        assert isinstance(self._question_payload, list), "Question payload must be a list of dicts."
+        if self._question_type == "model":
+            assert (
+                len(self._question_payload) == 2
+            ), "Payload for model question must contain two dicts."
+            for payload_element_index, payload_element in enumerate(self._question_payload):
+                if payload_element_index == 0:
+                    ConfirmModelDoc(**payload_element)
+                if payload_element_index == 1:
+                    DescriptionTextInput(**payload_element)
+
+        elif self._question_type == "undocumented_columns":
+            MultipleChoiceInput(**self._question_payload[0])
+
+        else:
+            raise NotImplementedError(f"{self._question_type} is not implemented.")
+
+        self._is_valid_question_payload = True
+
+    @staticmethod
+    def _iterate_through_columns(cols: List[str]) -> Dict[str, str]:
+        results = dict()
+        for column in cols:
+            results.update(
+                {column: questionary.text(message=f"{column}: {DESCRIPTION_PROMPT_MESSAGE}").ask()}
+            )
+
+        return results
+
+    def collect(self) -> Mapping[str, Union[bool, str]]:
+        """Question orchestractor function.
+
+        Depending on the question type provided on the class will call payload validation and
+        orchestrate documentation input collection.
+
+        - When `question_type` == 'model' the following dict is returned:
+        ```python
+        {'wants_to_document_model': True, 'model_description': 'New def'}
+        ```
+        - When `question_type` == 'undocumented_columns` the following dict is returned:
+        ```python
+        {'col_a': 'Description for col a', 'col_b': 'Description for col b'}
+        ```
+
+        Raises:
+            NotImplementedError: When a non supported `question_type` is provided
+
+        Returns:
+            Mapping[str, Union[bool, str]]: Response object for the backend documentation task.
+                See above for examples.
+        """
+        results = dict()
+        self._validate_question_payload()
+
+        # Model Documentation Flow
+        if self._question_type == "model":
+            for i, payload_element in enumerate(self._question_payload):
+                results.update(questionary.prompt(payload_element))
+                if i == 0 and results.get("wants_to_document_model") is False:
+                    break
+            return results
+
+        # Undocumented Columns Documentation Flow
+        if self._question_type == "undocumented_columns":
+            # first ask if all columns should be documented,
+            columns_to_document = self._question_payload[0].get("choices", list())
+            document_all_cols = questionary.confirm(
+                message=(
+                    f"There are {len(columns_to_document)} undocumented columns. "
+                    "Do you want to document them all?"
+                ),
+                auto_enter=True,
+            ).ask()
+
+            # iterate through all cols one by one
+            if document_all_cols:
+                results = self._iterate_through_columns(cols=columns_to_document)
+            else:
+                # reduce the list of columns
+                columns_to_document = questionary.prompt(self._question_payload)
+                print(columns_to_document)
+                # iterate through reduced list
+                results = self._iterate_through_columns(
+                    cols=columns_to_document["cols_to_document"]
+                )
+            return results
+
+        raise NotImplementedError(f"{self._question_type} is not implemented.")

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -197,7 +197,7 @@ class UserInputCollector:
         if self._question_type == "model":
             for i, payload_element in enumerate(self._question_payload):
                 results.update(questionary.prompt(payload_element))
-                if i == 0 and results.get("wants_to_document_model") is False:
+                if i < 1 and results.get("wants_to_document_model") is False:
                     break
             return results
 
@@ -219,7 +219,6 @@ class UserInputCollector:
             else:
                 # reduce the list of columns
                 columns_to_document = questionary.prompt(self._question_payload)
-                print(columns_to_document)
                 # iterate through reduced list
                 results = self._iterate_through_columns(
                     cols=columns_to_document["cols_to_document"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -199,11 +199,11 @@ cffi = ">=1.8,<1.11.3 || >1.11.3"
 six = ">=1.4.1"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0)", "sphinx-rtd-theme"]
+docs = ["sphinx (>=1.6.5,<1.8.0 || >1.8.0)", "sphinx-rtd-theme"]
 docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 idna = ["idna (>=2.1)"]
 pep8test = ["flake8", "flake8-import-order", "pep8-naming"]
-test = ["pytest (>=3.6.0,!=3.9.0,!=3.9.1,!=3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,<3.79.2 || >3.79.2)"]
 
 [[package]]
 name = "dataclasses"
@@ -401,11 +401,11 @@ protobuf = ">=3.6.0"
 six = ">=1.13.0,<2.0.0dev"
 
 [package.extras]
-all = ["google-cloud-bigquery-storage (>=0.6.0,<2.0.0dev)", "grpcio (>=1.8.2,<2.0dev)", "pyarrow (>=0.16.0,<2.0dev)", "pandas (>=0.17.1)", "pyarrow (>=0.4.1,!=0.14.0)", "tqdm (>=4.0.0,<5.0.0dev)"]
+all = ["google-cloud-bigquery-storage (>=0.6.0,<2.0.0dev)", "grpcio (>=1.8.2,<2.0dev)", "pyarrow (>=0.16.0,<2.0dev)", "pandas (>=0.17.1)", "pyarrow (>=0.4.1,<0.14.0 || >0.14.0)", "tqdm (>=4.0.0,<5.0.0dev)"]
 bqstorage = ["google-cloud-bigquery-storage (>=0.6.0,<2.0.0dev)", "grpcio (>=1.8.2,<2.0dev)", "pyarrow (>=0.16.0,<2.0dev)"]
 fastparquet = ["fastparquet", "python-snappy", "llvmlite (<=0.31.0)"]
 pandas = ["pandas (>=0.17.1)"]
-pyarrow = ["pyarrow (>=0.4.1,!=0.14.0)"]
+pyarrow = ["pyarrow (>=0.4.1,<0.14.0 || >0.14.0)"]
 tqdm = ["tqdm (>=4.0.0,<5.0.0dev)"]
 
 [[package]]
@@ -499,7 +499,7 @@ zipp = {version = ">=0.4", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "incremental"
@@ -605,7 +605,7 @@ SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "leather"
@@ -816,6 +816,17 @@ python-versions = "*"
 colorama = "*"
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.10"
+description = "Library for building powerful interactive command lines in Python"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+wcwidth = "*"
+
+[[package]]
 name = "protobuf"
 version = "3.11.3"
 description = "Protocol Buffers"
@@ -981,7 +992,7 @@ coverage = ">=4.4"
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-datafiles"
@@ -1080,6 +1091,20 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "questionary"
+version = "1.9.0"
+description = "Python library to build pretty command line user prompts ⭐️"
+category = "main"
+optional = false
+python-versions = ">=3.6,<3.10"
+
+[package.dependencies]
+prompt_toolkit = ">=2.0,<4.0"
+
+[package.extras]
+docs = ["Sphinx (>=3.3,<4.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)"]
+
+[[package]]
 name = "requests"
 version = "2.23.0"
 description = "Python HTTP for Humans."
@@ -1095,7 +1120,7 @@ urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
-socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
 
 [[package]]
 name = "requests-oauthlib"
@@ -1182,8 +1207,8 @@ urllib3 = ">=1.20,<1.26.0"
 
 [package.extras]
 development = ["pytest", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "coverage", "pexpect", "mock", "pytz", "pytzdata", "cython", "pendulum (!=2.1.1)", "more-itertools", "numpy"]
-pandas = ["pyarrow (>=0.17.0,<0.18.0)", "pandas (==0.24.2)", "pandas (>=1.0.0,<1.1.0)"]
-secure-local-storage = ["keyring (!=16.1.0,<22.0.0)"]
+pandas = ["pyarrow (>=0.17.0,<0.18.0)", "pandas (0.24.2)", "pandas (>=1.0.0,<1.1.0)"]
+secure-local-storage = ["keyring (<16.1.0 || >16.1.0,<22.0.0)"]
 
 [[package]]
 name = "snowflake-sqlalchemy"
@@ -1198,7 +1223,7 @@ snowflake-connector-python = "<3.0.0"
 sqlalchemy = "<2.0.0"
 
 [package.extras]
-development = ["pytest (<6.1.0)", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "coverage", "pexpect", "mock", "pytz", "pytzdata", "cython", "more-itertools", "numpy", "pandas (==0.24.2)", "pandas (>=1.0.0,<1.1.0)"]
+development = ["pytest (<6.1.0)", "pytest-cov", "pytest-rerunfailures", "pytest-timeout", "coverage", "pexpect", "mock", "pytz", "pytzdata", "cython", "more-itertools", "numpy", "pandas (0.24.2)", "pandas (>=1.0.0,<1.1.0)"]
 
 [[package]]
 name = "sqlalchemy"
@@ -1331,7 +1356,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
 secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
-socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -1352,6 +1377,14 @@ six = ">=1.9.0,<2"
 [package.extras]
 docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "pytest-xdist (>=1.31.0)", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "werkzeug"
@@ -1376,12 +1409,12 @@ python-versions = ">=3.6"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.3,<4.0"
-content-hash = "4885906e1e5274ee485f0aeb8778a076832d0d959edc0c294329469efa524ee0"
+python-versions = ">=3.6.3,<3.10"
+content-hash = "0a5a176fb4ca5a2dda37b7fe36c35e8d6a0cb1308b6858ee45cd33c7e3eb931f"
 
 [metadata.files]
 agate = [
@@ -1458,13 +1491,11 @@ cffi = [
     {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
     {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
-    {file = "cffi-1.14.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:a5ed8c05548b54b998b9498753fb9cadbfd92ee88e884641377d8a8b291bcc01"},
     {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
     {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
     {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
     {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
-    {file = "cffi-1.14.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d5ff0621c88ce83a28a10d2ce719b2ee85635e85c515f12bac99a95306da4b2e"},
     {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
     {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
     {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
@@ -1790,6 +1821,10 @@ pretty-errors = [
     {file = "pretty_errors-1.2.19-py3-none-any.whl", hash = "sha256:87fd3071dbc302c9064f5b9a6114ea1678dda6ace70cbcd1452e46661af408e6"},
     {file = "pretty_errors-1.2.19.tar.gz", hash = "sha256:b37b8a84634e9e6294273926e9cdea99414390e9a329293d018a1b4bbe8e2aa7"},
 ]
+prompt-toolkit = [
+    {file = "prompt_toolkit-3.0.10-py3-none-any.whl", hash = "sha256:ac329c69bd8564cb491940511957312c7b8959bb5b3cf3582b406068a51d5bb7"},
+    {file = "prompt_toolkit-3.0.10.tar.gz", hash = "sha256:b8b3d0bde65da350290c46a8f54f336b3cbf5464a4ac11239668d986852e79d5"},
+]
 protobuf = [
     {file = "protobuf-3.11.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ef2c2e56aaf9ee914d3dccc3408d42661aaf7d9bb78eaa8f17b2e6282f214481"},
     {file = "protobuf-3.11.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:dd9aa4401c36785ea1b6fff0552c674bdd1b641319cb07ed1fe2392388e9b0d7"},
@@ -2028,9 +2063,11 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
+questionary = [
+    {file = "questionary-1.9.0-py3-none-any.whl", hash = "sha256:fa50c06af4e3826d986efbc90be16e42ff367a634e6a169e42a3f9fccd90648b"},
+    {file = "questionary-1.9.0.tar.gz", hash = "sha256:a050fdbb81406cddca679a6f492c6272da90cb09988963817828f697cf091c55"},
 ]
 requests = [
     {file = "requests-2.23.0-py2.7.egg", hash = "sha256:5d2d0ffbb515f39417009a46c14256291061ac01ba8f875b90cad137de83beb4"},
@@ -2191,6 +2228,10 @@ urllib3 = [
 virtualenv = [
     {file = "virtualenv-20.2.2-py2.py3-none-any.whl", hash = "sha256:54b05fc737ea9c9ee9f8340f579e5da5b09fb64fd010ab5757eb90268616907c"},
     {file = "virtualenv-20.2.2.tar.gz", hash = "sha256:b7a8ec323ee02fb2312f098b6b4c9de99559b462775bc8fe3627a73706603c1b"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 werkzeug = [
     {file = "Werkzeug-0.16.1-py2.py3-none-any.whl", hash = "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -152,6 +152,14 @@ python-versions = "*"
 pycparser = "*"
 
 [[package]]
+name = "cfgv"
+version = "3.2.0"
+description = "Validate configuration and produce human readable error messages."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[[package]]
 name = "chardet"
 version = "3.0.4"
 description = "Universal encoding detector for Python 2 and 3"
@@ -464,6 +472,17 @@ jsonschema = ">=3.0,<3.2"
 python-dateutil = ">=2.8,<2.9"
 
 [[package]]
+name = "identify"
+version = "1.5.11"
+description = "File identification library for Python"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.extras]
+license = ["editdistance"]
+
+[[package]]
 name = "idna"
 version = "2.9"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -737,6 +756,14 @@ pyyaml = ["pyyaml"]
 scipy = ["scipy"]
 
 [[package]]
+name = "nodeenv"
+version = "1.5.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "oauthlib"
 version = "3.1.0"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -803,6 +830,24 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 importlib-metadata = {version = ">=1.7.0,<2.0.0", markers = "python_version >= \"2.7\" and python_version < \"2.8\" or python_version >= \"3.5\" and python_version < \"3.8\""}
+
+[[package]]
+name = "pre-commit"
+version = "2.9.3"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+importlib-resources = {version = "*", markers = "python_version < \"3.7\""}
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+toml = "*"
+virtualenv = ">=20.0.8"
 
 [[package]]
 name = "pretty-errors"
@@ -1414,7 +1459,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.3,<3.10"
-content-hash = "0a5a176fb4ca5a2dda37b7fe36c35e8d6a0cb1308b6858ee45cd33c7e3eb931f"
+content-hash = "0378bc48ee475fe074dfc6a099d7241d0c2ebc06cfbe72d623f5f157dc92e415"
 
 [metadata.files]
 agate = [
@@ -1504,6 +1549,10 @@ cffi = [
     {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
     {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
     {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
+]
+cfgv = [
+    {file = "cfgv-3.2.0-py2.py3-none-any.whl", hash = "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d"},
+    {file = "cfgv-3.2.0.tar.gz", hash = "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -1661,6 +1710,10 @@ hologram = [
     {file = "hologram-0.0.10-py3-none-any.whl", hash = "sha256:a1011b18271829d01e4ec16e1822c73345d8fb8f8497db130e1c6710292ef9ed"},
     {file = "hologram-0.0.10.tar.gz", hash = "sha256:d898059ea675bf5159361fd3a61d878c0e5cd66cec98e0dd57ba316af8c8f9e7"},
 ]
+identify = [
+    {file = "identify-1.5.11-py2.py3-none-any.whl", hash = "sha256:7aef7a5104d6254c162990e54a203cdc0fd202046b6c415bd5d636472f6565c4"},
+    {file = "identify-1.5.11.tar.gz", hash = "sha256:b2c71bf9f5c482c389cef816f3a15f1c9d7429ad70f497d4a2e522442d80c6de"},
+]
 idna = [
     {file = "idna-2.9-py2.py3-none-any.whl", hash = "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"},
     {file = "idna-2.9.tar.gz", hash = "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb"},
@@ -1793,6 +1846,10 @@ networkx = [
     {file = "networkx-2.5-py3-none-any.whl", hash = "sha256:8c5812e9f798d37c50570d15c4a69d5710a18d77bafc903ee9c5fba7454c616c"},
     {file = "networkx-2.5.tar.gz", hash = "sha256:7978955423fbc9639c10498878be59caf99b44dc304c2286162fd24b458c1602"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.5.0-py2.py3-none-any.whl", hash = "sha256:5304d424c529c997bc888453aeaa6362d242b6b4631e90f3d4bf1b290f1c84a9"},
+    {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
+]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
     {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
@@ -1816,6 +1873,10 @@ pluggy = [
 poetry-core = [
     {file = "poetry-core-1.0.0.tar.gz", hash = "sha256:6a664ff389b9f45382536f8fa1611a0cb4d2de7c5a5c885db1f0c600cd11fbd5"},
     {file = "poetry_core-1.0.0-py2.py3-none-any.whl", hash = "sha256:769288e0e1b88dfcceb3185728f0b7388b26d5f93d6c22d2dcae372da51d200d"},
+]
+pre-commit = [
+    {file = "pre_commit-2.9.3-py2.py3-none-any.whl", hash = "sha256:6c86d977d00ddc8a60d68eec19f51ef212d9462937acf3ea37c7adec32284ac0"},
+    {file = "pre_commit-2.9.3.tar.gz", hash = "sha256:ee784c11953e6d8badb97d19bc46b997a3a9eded849881ec587accd8608d74a4"},
 ]
 pretty-errors = [
     {file = "pretty_errors-1.2.19-py3-none-any.whl", hash = "sha256:87fd3071dbc302c9064f5b9a6114ea1678dda6ace70cbcd1452e46661af408e6"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1338,7 +1338,7 @@ toml = "*"
 
 [[package]]
 name = "tox"
-version = "3.20.1"
+version = "3.20.0"
 description = "tox is a generic virtualenv management and test command line tool"
 category = "dev"
 optional = false
@@ -1347,7 +1347,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [package.dependencies]
 colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
 filelock = ">=3.0.0"
-importlib-metadata = {version = ">=0.12,<3", markers = "python_version < \"3.8\""}
+importlib-metadata = {version = ">=0.12,<2", markers = "python_version < \"3.8\""}
 packaging = ">=14"
 pluggy = ">=0.12.0"
 py = ">=1.4.17"
@@ -1459,7 +1459,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.3,<3.10"
-content-hash = "0378bc48ee475fe074dfc6a099d7241d0c2ebc06cfbe72d623f5f157dc92e415"
+content-hash = "c2fa6ea5971cc77f31534b85934dd6204eb12fde327f17312c858ac37a56f5fc"
 
 [metadata.files]
 agate = [
@@ -2238,8 +2238,8 @@ towncrier = [
     {file = "towncrier-19.2.0.tar.gz", hash = "sha256:48251a1ae66d2cf7e6fa5552016386831b3e12bb3b2d08eb70374508c17a8196"},
 ]
 tox = [
-    {file = "tox-3.20.1-py2.py3-none-any.whl", hash = "sha256:42ce19ce5dc2f6d6b1fdc5666c476e1f1e2897359b47e0aa3a5b774f335d57c2"},
-    {file = "tox-3.20.1.tar.gz", hash = "sha256:4321052bfe28f9d85082341ca8e233e3ea901fdd14dab8a5d3fbd810269fbaf6"},
+    {file = "tox-3.20.0-py2.py3-none-any.whl", hash = "sha256:e6318f404aff16522ff5211c88cab82b39af121735a443674e4e2e65f4e4637b"},
+    {file = "tox-3.20.0.tar.gz", hash = "sha256:eb629ddc60e8542fd4a1956b2462e3b8771d49f1ff630cecceacaa0fbfb7605a"},
 ]
 tox-poetry-installer = [
     {file = "tox-poetry-installer-0.6.1.tar.gz", hash = "sha256:8dfdf09004ad0bc628dacc258c2b8fe4a3708b038b5ab3d5ed7ec4045f6ae409"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-sugar="dbt_sugar.core.main:main"
+dbt-sugar="dbt_sugar.core.main:main"
 
 
 [tool.towncrier]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pytest-sugar = "^0.9.4"
 pytest-datafiles = "^2.0"
 tox-poetry-installer = "^0.6.1"
 dbt = "^0.18.1"
+pre-commit = "^2.9.3"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["data engineering", "dbt"]
 # homepage =
 
 [tool.poetry.dependencies]
-python = ">=3.6.3,<4.0"
+python = ">=3.6.3,<3.10"
 luddite = "^1.0.1"
 packaging = "^20.8"
 pretty-errors = "^1.2.19"
@@ -28,6 +28,7 @@ snowflake-sqlalchemy = ">=1.2.4"
 SQLAlchemy = "^1.3.22"
 pydantic = "^1.7.3"
 PyYAML = "^5.3.1"
+questionary = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ questionary = "^1.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"
-tox = "^3.20.1"
 pytest-cov = "^2.10.1"
 mypy = "^0.790"
 towncrier = "^19.2.0"
@@ -43,6 +42,7 @@ pytest-datafiles = "^2.0"
 tox-poetry-installer = "^0.6.1"
 dbt = "^0.18.1"
 pre-commit = "^2.9.3"
+tox = "3.20.0"
 
 
 [build-system]

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -1,0 +1,107 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "question_type, question_payload, expected_results",
+    [
+        (
+            "model",
+            [
+                {
+                    "type": "confirm",
+                    "name": "wants_to_document_model",
+                    "message": "Model Description: This is my previously documented model. Document?",
+                    "default": True,
+                },
+                {
+                    "type": "text",
+                    "name": "model_description",
+                    "message": "Please write down your description:",
+                },
+            ],
+            {"prompt_ret": {"wants_to_document_model": True, "model_description": "New def"}},
+        ),
+        (
+            "model",
+            [
+                {
+                    "type": "confirm",
+                    "name": "wants_to_document_model",
+                    "message": "Model Description: This is my previously documented model. Document?",
+                    "default": True,
+                },
+                {
+                    "type": "text",
+                    "name": "model_description",
+                    "message": "Please write down your description:",
+                },
+            ],
+            {"prompt_ret": {"wants_to_document_model": False}},
+        ),
+        (
+            "undocumented_columns",
+            [
+                {
+                    "type": "checkbox",
+                    "name": "cols_to_document",
+                    "choices": ["col_a", "col_b"],
+                    "message": "Select the columns you want to document.",
+                }
+            ],
+            {
+                "confirm_ret": True,
+                "prompt_ret": {"col_a": "Custom desc", "col_b": "Custom desc"},
+                "text_ret": "Custom desc",
+            },
+        ),
+        (
+            "undocumented_columns",
+            [
+                {
+                    "type": "checkbox",
+                    "name": "cols_to_document",
+                    "choices": ["col_a", "col_b"],
+                    "message": "Select the columns you want to document.",
+                }
+            ],
+            {
+                "confirm_ret": False,
+                "prompt_ret": {"col_a": "Custom desc"},
+                "non_full_cols": {"cols_to_document": ["col_a"]},
+                "text_ret": "Custom desc",
+            },
+        ),
+        (
+            "non_implemented",
+            [],
+            {},
+        ),
+    ],
+)
+def test_collect(mocker, question_type, question_payload, expected_results):
+    from dbt_sugar.core.ui.cli_ui import UserInputCollector
+
+    # mock for the questionary.Question --this was a bit of a fuckery to test...
+    class Question:
+        def __init__(self, return_value):
+            self._return_value = return_value
+
+        def ask(self):
+            return self._return_value
+
+    if question_type == "model":
+        mocker.patch("questionary.prompt", return_value=expected_results.get("prompt_ret"))
+    else:
+        mocker.patch("questionary.prompt", return_value=expected_results.get("non_full_cols"))
+        mocker.patch(
+            "questionary.confirm", return_value=Question(expected_results.get("confirm_ret"))
+        )
+        mocker.patch("questionary.text", return_value=Question(expected_results.get("text_ret")))
+    input_collector = UserInputCollector(question_type, question_payload)
+
+    if question_type == "non_implemented":
+        with pytest.raises(NotImplementedError):
+            results = input_collector.collect()
+    else:
+        results = input_collector.collect()
+        assert results == expected_results.get("prompt_ret")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 FIXTURE_DIR = Path(__file__).resolve().parent
 
@@ -18,8 +19,8 @@ FIXTURE_DIR = Path(__file__).resolve().parent
 def test_Config(cli_args, test_desc):
     from dbt_sugar.core.config.config import DbtSugarConfig
     from dbt_sugar.core.flags import FlagParser
-    from dbt_sugar.core.main import parser
     from dbt_sugar.core.logger import GLOBAL_LOGGER as logger
+    from dbt_sugar.core.main import parser
 
     flag_parser = FlagParser(parser)
     if test_desc == "non_allowed_command":
@@ -42,14 +43,10 @@ def test_Config(cli_args, test_desc):
 )
 @pytest.mark.datafiles(FIXTURE_DIR)
 def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missing_dbt_project):
-    from dbt_sugar.core.main import parser
-    from dbt_sugar.core.flags import FlagParser
     from dbt_sugar.core.config.config import DbtSugarConfig
-    from dbt_sugar.core.exceptions import (
-        SyrupNotFoundError,
-        NoSyrupProvided,
-        MissingDbtProjects,
-    )
+    from dbt_sugar.core.exceptions import MissingDbtProjects, NoSyrupProvided, SyrupNotFoundError
+    from dbt_sugar.core.flags import FlagParser
+    from dbt_sugar.core.main import parser
 
     expectation = {
         "name": "syrup_1",

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from dbt_sugar.core.clients.dbt import DbtProfile
 from dbt_sugar.core.task.base import COLUMN_NOT_DOCUMENTED

--- a/tests/handle_test.py
+++ b/tests/handle_test.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from dbt_sugar.core.task.doc import DocumentationTask
 

--- a/tests/postgres_test.py
+++ b/tests/postgres_test.py
@@ -1,6 +1,5 @@
 import sqlalchemy
 
-
 CREDENTIALS = dict(user="dbt_sugar_test_user", password="magical_password", database="dbt_sugar")
 
 

--- a/tests/snowflake_test.py
+++ b/tests/snowflake_test.py
@@ -1,6 +1,5 @@
 import sqlalchemy
 
-
 CREDENTIALS = dict(
     user="dbt_sugar_test_user",
     password="magical_password",

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -1,7 +1,8 @@
 import os
-from pathlib import Path
-import pytest
 import tempfile
+from pathlib import Path
+
+import pytest
 import yaml
 
 from dbt_sugar.core.clients.yaml_helpers import open_yaml, save_yaml


### PR DESCRIPTION
# Description
Adds the Front-End side of the `DocumentationTask` UI.

Defines the API contract between the front end and back end of the documentation task.
Orchestrate user input collection flow.

# How was the change tested
Tested interactively so far, need to see how we can similate user input in pytest to place unit tests all the code introduced in this PR.

# Issue Information
Addresses the Front-End side of #44 

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
