### PR TITLE
feat(ui): implement already document cols FE API

### DIFF
--- a/changelog/50.feature.rst
+++ b/changelog/50.feature.rst
@@ -1,0 +1,2 @@
+``dbt-sugar`` now offers documentation UI flow for **already documented columns**. The user is prompted to answer a "yes/no" to whether they want to document already documented columns. If they choose to do so they are presented with a list of columns to choose from. Each column also shows the current description.
+<INSERT GIF OF FLOW WHEN GENERATING CHANGELOG>

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -251,7 +251,7 @@ class UserInputCollector:
 
         return results
 
-    def collect(self) -> Mapping[str, Union[bool, str]]:
+    def collect(self) -> Dict[str, Any]:
         """Question orchestractor function.
 
         Depending on the question type provided on the class will call payload validation and

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -1,6 +1,7 @@
 """User Input Collector API."""
 
-from typing import Any, Dict, List, Mapping, Sequence, Union
+import copy
+from typing import Any, Dict, List, Mapping, Sequence, Union, cast
 
 import questionary
 from pydantic import BaseModel, validator
@@ -84,6 +85,12 @@ class MultipleChoiceInput(BaseModel):
         return value
 
 
+class MultipleChoiceInputWithDict(MultipleChoiceInput):
+    """Validation model for a multiple choice question type where the choices list is a dict."""
+
+    choices: Dict[str, str]  # type: ignore # because mypy doesn't like this but I'm ok with it.
+
+
 class UserInputCollector:
     """User input collector class.
 
@@ -153,6 +160,9 @@ class UserInputCollector:
         elif self._question_type == "undocumented_columns":
             MultipleChoiceInput(**self._question_payload[0])
 
+        elif self._question_type == "documented_columns":
+            MultipleChoiceInputWithDict(**self._question_payload[0])
+
         else:
             raise NotImplementedError(f"{self._question_type} is not implemented.")
 
@@ -162,9 +172,9 @@ class UserInputCollector:
     def _iterate_through_columns(cols: List[str]) -> Dict[str, str]:
         results = dict()
         for column in cols:
-            results.update(
-                {column: questionary.text(message=f"{column}: {DESCRIPTION_PROMPT_MESSAGE}").ask()}
-            )
+            description = questionary.text(message=f"{column}: {DESCRIPTION_PROMPT_MESSAGE}").ask()
+            if description:
+                results.update({column: description})
 
         return results
 
@@ -183,7 +193,9 @@ class UserInputCollector:
         return results
 
     @classmethod
-    def _document_undocumented_cols(cls, question_payload: Sequence[Mapping[str, Any]]):
+    def _document_undocumented_cols(
+        cls, question_payload: Sequence[Mapping[str, Any]]
+    ) -> Dict[str, str]:
         results = dict()
         columns_to_document = question_payload[0].get("choices", list())
         # check if user wants to document all columns
@@ -203,19 +215,37 @@ class UserInputCollector:
             results = cls._iterate_through_columns(cols=columns_to_document["cols_to_document"])
         return results
 
-    @staticmethod
-    def document_already_documented_cols(question_payload: Sequence[Mapping[str, Any]]):
-        # ask user if they want to see any of the documented columns?
-        # ask if user has a particular column in mind that they want to re-document
-        # if so ask them to type it.
-        # collect input
-        # if no particular columns user will be asked if they want to see the documented columns.
-        # if yes, render a table of 10 cols per "page"
-        # for each page ask if user wants to document any of the columns?
-        # if so, we pop the checkbox dialogue
-        # if not we ask if user wants to go to next page?
+    @classmethod
+    def _document_already_documented_cols(
+        cls, question_payload: Sequence[Mapping[str, Any]]
+    ) -> Dict[str, str]:
+        mutable_payload = copy.deepcopy(question_payload)
+        mutable_payload = cast(Sequence[Dict[str, Any]], mutable_payload)
 
-        ...
+        # massage the question payload
+        choices = []
+        for col, desc in mutable_payload[0].get("choices", dict()).items():
+            choices.append(f"{col} | {desc}")
+        mutable_payload[0].update({"choices": choices})
+
+        # ask user if they want to see any of the documented columns?
+        results = dict()
+        document_any_columns = questionary.confirm(
+            message="Do you want to document any of the already documented columns in this model?",
+            auto_enter=True,
+        ).ask()
+
+        if document_any_columns:
+            columns_to_document = questionary.prompt(mutable_payload)
+            _results = cls._iterate_through_columns(cols=columns_to_document["cols_to_document"])
+
+            # remove description from col key
+            for col, desc in _results.items():
+                stripped_col_name = col.split("|")[0].strip()
+                results.update({stripped_col_name: desc})
+            return results
+
+        return results
 
     def collect(self) -> Mapping[str, Union[bool, str]]:
         """Question orchestractor function.
@@ -248,5 +278,8 @@ class UserInputCollector:
         # Undocumented Columns Documentation Flow
         if self._question_type == "undocumented_columns":
             return self._document_undocumented_cols(self._question_payload)
+
+        if self._question_type == "documented_columns":
+            return self._document_already_documented_cols(self._question_payload)
 
         raise NotImplementedError(f"{self._question_type} is not implemented.")

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -197,7 +197,11 @@ class UserInputCollector:
         if self._question_type == "model":
             for i, payload_element in enumerate(self._question_payload):
                 results.update(questionary.prompt(payload_element))
+<<<<<<< HEAD
                 if i < 1 and results.get("wants_to_document_model") is False:
+=======
+                if i == 0 and results.get("wants_to_document_model") is False:
+>>>>>>> 9a3be2a... Implement UserInputCollector UI API
                     break
             return results
 
@@ -219,6 +223,10 @@ class UserInputCollector:
             else:
                 # reduce the list of columns
                 columns_to_document = questionary.prompt(self._question_payload)
+<<<<<<< HEAD
+=======
+                print(columns_to_document)
+>>>>>>> 9a3be2a... Implement UserInputCollector UI API
                 # iterate through reduced list
                 results = self._iterate_through_columns(
                     cols=columns_to_document["cols_to_document"]

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -203,7 +203,18 @@ class UserInputCollector:
             results = cls._iterate_through_columns(cols=columns_to_document["cols_to_document"])
         return results
 
-    def document_already_documented_cols(self):
+    @staticmethod
+    def document_already_documented_cols(question_payload: Sequence[Mapping[str, Any]]):
+        # ask user if they want to see any of the documented columns?
+        # ask if user has a particular column in mind that they want to re-document
+        # if so ask them to type it.
+        # collect input
+        # if no particular columns user will be asked if they want to see the documented columns.
+        # if yes, render a table of 10 cols per "page"
+        # for each page ask if user wants to document any of the columns?
+        # if so, we pop the checkbox dialogue
+        # if not we ask if user wants to go to next page?
+
         ...
 
     def collect(self) -> Mapping[str, Union[bool, str]]:

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -197,11 +197,7 @@ class UserInputCollector:
         if self._question_type == "model":
             for i, payload_element in enumerate(self._question_payload):
                 results.update(questionary.prompt(payload_element))
-<<<<<<< HEAD
                 if i < 1 and results.get("wants_to_document_model") is False:
-=======
-                if i == 0 and results.get("wants_to_document_model") is False:
->>>>>>> 9a3be2a... Implement UserInputCollector UI API
                     break
             return results
 
@@ -223,10 +219,6 @@ class UserInputCollector:
             else:
                 # reduce the list of columns
                 columns_to_document = questionary.prompt(self._question_payload)
-<<<<<<< HEAD
-=======
-                print(columns_to_document)
->>>>>>> 9a3be2a... Implement UserInputCollector UI API
                 # iterate through reduced list
                 results = self._iterate_through_columns(
                     cols=columns_to_document["cols_to_document"]

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -185,7 +185,11 @@ class UserInputCollector:
         results = dict()
         for i, payload_element in enumerate(question_payload):
             results.update(questionary.prompt(payload_element))
-            collect_model_description = i < 1 and results.get("wants_to_document_model") is False
+            collect_model_description = i < 1 and results.get("wants_to_document_model") is True
+
+            if not results.get("model_description"):
+                # we return an empty dict if user decided to not enter a description in the end.
+                results = dict()
             if collect_model_description is False:
                 # if the user doesnt want to document the model we exit early even if the payload
                 # has a second entry which would trigger the description collection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,7 @@ pytest-datafiles = "^2.0"
 tox-poetry-installer = "^0.6.1"
 dbt = "^0.18.1"
 pre-commit = "^2.9.3"
-<<<<<<< HEAD
 tox = "3.20.0"
-=======
->>>>>>> 86fd118... add pre-commit to dev requirements
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,10 @@ pytest-datafiles = "^2.0"
 tox-poetry-installer = "^0.6.1"
 dbt = "^0.18.1"
 pre-commit = "^2.9.3"
+<<<<<<< HEAD
 tox = "3.20.0"
+=======
+>>>>>>> 86fd118... add pre-commit to dev requirements
 
 
 [build-system]

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -164,7 +164,6 @@ def test_collect(mocker, question_type, question_payload, expected_results):
         and expected_results.get("prompt_ret").get("model_description") == ""
         or expected_results.get("prompt_ret").get("wants_to_document_model") is False
     ):
-        print(expected_results)
         results = input_collector.collect()
         assert results == dict()
     else:

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -39,6 +39,23 @@ import pytest
             {"prompt_ret": {"wants_to_document_model": False}},
         ),
         (
+            "model",
+            [
+                {
+                    "type": "confirm",
+                    "name": "wants_to_document_model",
+                    "message": "Model Description: This is my previously documented model. Document?",
+                    "default": True,
+                },
+                {
+                    "type": "text",
+                    "name": "model_description",
+                    "message": "Please write down your description:",
+                },
+            ],
+            {"prompt_ret": {"wants_to_document_model": True, "model_description": ""}},
+        ),
+        (
             "undocumented_columns",
             [
                 {
@@ -144,6 +161,14 @@ def test_collect(mocker, question_type, question_payload, expected_results):
     if question_type == "non_implemented":
         with pytest.raises(NotImplementedError):
             results = input_collector.collect()
+    elif (
+        question_type == "model"
+        and expected_results.get("prompt_ret").get("model_description") == ""
+        or expected_results.get("prompt_ret").get("wants_to_document_model") is False
+    ):
+        print(expected_results)
+        results = input_collector.collect()
+        assert results == dict()
     else:
         results = input_collector.collect()
         assert results == expected_results.get("prompt_ret")

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -94,7 +94,6 @@ import pytest
                 {
                     "type": "checkbox",
                     "name": "cols_to_document",
-                    # "choices": ["col_a", "col_b"],
                     "choices": {
                         "col_a": "Column a description",
                         "column_b": "Column b description",
@@ -115,7 +114,6 @@ import pytest
                 {
                     "type": "checkbox",
                     "name": "cols_to_document",
-                    # "choices": ["col_a", "col_b"],
                     "choices": {
                         "col_a": "Column a description",
                         "column_b": "Column b description",

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -72,6 +72,48 @@ import pytest
             },
         ),
         (
+            "documented_columns",
+            [
+                {
+                    "type": "checkbox",
+                    "name": "cols_to_document",
+                    # "choices": ["col_a", "col_b"],
+                    "choices": {
+                        "col_a": "Column a description",
+                        "column_b": "Column b description",
+                    },
+                    "message": "Select the columns you want to document.",
+                }
+            ],
+            {
+                "confirm_ret": True,
+                "prompt_ret": {"col_a": "Custom desc"},
+                "non_full_cols": {"cols_to_document": ["col_a"]},
+                "text_ret": "Custom desc",
+            },
+        ),
+        (
+            "documented_columns",
+            [
+                {
+                    "type": "checkbox",
+                    "name": "cols_to_document",
+                    # "choices": ["col_a", "col_b"],
+                    "choices": {
+                        "col_a": "Column a description",
+                        "column_b": "Column b description",
+                    },
+                    "message": "Select the columns you want to document.",
+                }
+            ],
+            {
+                "confirm_ret": False,
+                "prompt_ret": {},
+                "non_full_cols": {"cols_to_document": ["col_a"]},
+                "text_ret": "Custom desc",
+            },
+        ),
+        (
             "non_implemented",
             [],
             {},


### PR DESCRIPTION
# Description
Adds UI user input flow for already documented columns.

The API will expect the following input:
```python
question_type = 'documented_columns'
question_payload = [
    {
      "type": "checkbox",
      "name": "cols_to_document",
      "choices": {
        "col_a": "Column a description",
        "column_b": "Column b description",
      },
     "message": "Select the columns you want to document.",
     }
]

c = UserInputCollector(question_type, question_payload)
c.collect()
```
and will return a response that looks like:
```python
{'col_a': 'New description'}

```

UI looks like this:
![Screen Recording 2021-01-16 at 03 56 PM](https://user-images.githubusercontent.com/4304794/104815274-d5d41100-5813-11eb-9543-d03250c53ad3.gif)


# How was the change tested
Unit tests are added and passing locally.

# Issue Information
Partially addresses #44

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
