### PR TITLE
feat: parse profile name from dbt_project

### DIFF
--- a/dbt_sugar/core/clients/dbt.py
+++ b/dbt_sugar/core/clients/dbt.py
@@ -113,7 +113,7 @@ class DbtProfile(BaseYamlConfig):
     def __init__(
         self,
         profile_name: str,
-        project_name: str,
+        # project_name: str,
         target_name: str,  # TODO:Maybe make this optional?
         profiles_dir: Optional[Path] = None,
     ) -> None:
@@ -125,7 +125,7 @@ class DbtProfile(BaseYamlConfig):
                 "outputs" in the dbt's profile.yml (https://docs.getdbt.com/dbt-cli/configure-your-profile/)
         """
         # attrs parsed from constructor
-        self.project_name = project_name
+        self._profile_name = profile_name
         # TODO: dbt profile allows for a default target to be specified. We might want to allow
         # for this to be null and parse the target from "target:" key.
         self.target_name = target_name
@@ -145,7 +145,7 @@ class DbtProfile(BaseYamlConfig):
             self.profiles_dir
         )  # this will raise so no need to check exists further
         _profile_dict = open_yaml(self.profiles_dir)
-        _profile_dict = _profile_dict.get(self.project_name, _profile_dict.get("default"))
+        _profile_dict = _profile_dict.get(self._profile_name, _profile_dict.get("default"))
         if _profile_dict:
             _target_profile = _profile_dict["outputs"].get(self.target_name)
 
@@ -157,11 +157,11 @@ class DbtProfile(BaseYamlConfig):
             else:
                 raise ProfileParsingError(
                     f"Could not find an entry for target: {self.target_name}, "
-                    f"under the {self.project_name} config."
+                    f"under the {self._profile_name} config."
                 )
 
         else:
             raise ProfileParsingError(
-                f"Could not find an entry for {self.project_name} in your profiles.yml "
+                f"Could not find an entry for {self._profile_name} in your profiles.yml "
                 f"located in {self.profiles_dir}."
             )

--- a/dbt_sugar/core/clients/dbt.py
+++ b/dbt_sugar/core/clients/dbt.py
@@ -56,7 +56,6 @@ class BaseYamlConfig:
     """Base class object which gets extended by objects which will generally read from yaml configs."""
 
     def _assert_file_exists(self, dir: Path, filename: str = "profiles.yml") -> bool:
-        # TODO: We'll want to allow users to override this path.
         logger.debug(dir.resolve())
         if dir.is_file():
             return True

--- a/dbt_sugar/core/clients/dbt.py
+++ b/dbt_sugar/core/clients/dbt.py
@@ -1,12 +1,16 @@
 """Holds methods to interact with dbt API (we mostly don't for now because not stable) and objects."""
 
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel, root_validator
 
 from dbt_sugar.core.clients.yaml_helpers import open_yaml
-from dbt_sugar.core.exceptions import DbtProfileFileMissing, ProfileParsingError
+from dbt_sugar.core.exceptions import (
+    DbtProfileFileMissing,
+    ProfileParsingError,
+    TargetNameNotProvided,
+)
 from dbt_sugar.core.logger import GLOBAL_LOGGER as logger
 
 DEFAULT_DBT_PROFILE_PATH = Path.home().joinpath(".dbt", "profiles").with_suffix(".yml")
@@ -114,8 +118,7 @@ class DbtProfile(BaseYamlConfig):
     def __init__(
         self,
         profile_name: str,
-        # project_name: str,
-        target_name: str,  # TODO:Maybe make this optional?
+        target_name: str,
         profiles_dir: Optional[Path] = None,
     ) -> None:
         """Reads, validates and holds dbt profile info required by dbt-sugar (mainly db creds).
@@ -129,7 +132,7 @@ class DbtProfile(BaseYamlConfig):
         self._profile_name = profile_name
         # TODO: dbt profile allows for a default target to be specified. We might want to allow
         # for this to be null and parse the target from "target:" key.
-        self.target_name = target_name
+        self._target_name = target_name
         self._profiles_dir = profiles_dir
 
         # attrs populated by class methods
@@ -141,14 +144,29 @@ class DbtProfile(BaseYamlConfig):
             return self._profiles_dir
         return DEFAULT_DBT_PROFILE_PATH
 
+    def _get_target_profile(self, profile_dict: Dict[str, Any]) -> Dict[str, Union[str, int]]:
+        if self._target_name:
+            return profile_dict["outputs"].get(self._target_name)
+        else:
+            self._target_name = profile_dict.get("target", str())
+            if self._target_name:
+                return profile_dict["outputs"].get(self._target_name)
+            else:
+                raise TargetNameNotProvided(
+                    f"No target name provied in {self._profiles_dir} and none provided via "
+                    "--target in CLI. Cannot figure out appropriate profile information to load."
+                )
+
     def read_profile(self):
         _ = self._assert_file_exists(
             self.profiles_dir
         )  # this will raise so no need to check exists further
         _profile_dict = open_yaml(self.profiles_dir)
-        _profile_dict = _profile_dict.get(self._profile_name, _profile_dict.get("default"))
+        _profile_dict = _profile_dict.get(self._profile_name, _profile_dict.get(self._profile_name))
         if _profile_dict:
-            _target_profile = _profile_dict["outputs"].get(self.target_name)
+
+            # read target name from args or try to get it from the dbt_profile `target:` field.
+            _target_profile = self._get_target_profile(profile_dict=_profile_dict)
 
             if _target_profile:
                 # uses pydantic to validate profile. It will raise and break app if invalid.
@@ -157,7 +175,7 @@ class DbtProfile(BaseYamlConfig):
                 self.profile = _target_profile.dict()
             else:
                 raise ProfileParsingError(
-                    f"Could not find an entry for target: {self.target_name}, "
+                    f"Could not find an entry for target: {self._target_name}, "
                     f"under the {self._profile_name} config."
                 )
 

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -59,6 +59,8 @@ class DbtSugarConfig:
         self._config_file_found_nearby = False
         self._max_folder_iterations = max_dir_upwards_iterations
         self._current_folder = Path.cwd()
+        if self._flags.profiles_dir:
+            self._current_folder = Path(self._flags.profiles_dir)
 
         # "externally offered objects"
         self.config_model: SyrupModel
@@ -66,6 +68,7 @@ class DbtSugarConfig:
     @property
     def config(self):
         if self.config_model:
+            logger.debug(f"Config model dict: {self.config_model.dict()}")
             return self.config_model.dict()
         raise AttributeError(f"{type(self).__name__} does not have a parsed config.")
 
@@ -125,7 +128,7 @@ class DbtSugarConfig:
         filename = Path(current).joinpath(self.SUGAR_CONFIG_FILENAME)
 
         if self._config_path == Path(str()):
-            logger.debug("Trying to find sygar_config.yml in current and parent folders")
+            logger.debug("Trying to find sugar_config.yml in current and parent folders")
 
             while folder_iteration < self._max_folder_iterations:
                 if filename.exists():
@@ -140,7 +143,7 @@ class DbtSugarConfig:
 
             else:
                 raise FileNotFoundError(
-                    f"Unable to find {self.SUGAR_CONFIG_FILENAME} in any nearby"
+                    f"Unable to find {self.SUGAR_CONFIG_FILENAME} in any nearby "
                     f"directories after {self._max_folder_iterations} iterations upwards."
                 )
 

--- a/dbt_sugar/core/exceptions.py
+++ b/dbt_sugar/core/exceptions.py
@@ -33,3 +33,7 @@ class NoSyrupProvided(DbtSugarException):
 
 class MissingDbtProjects(DbtSugarException):
     """Thrown when one or more in-scope dbt projects could not be found."""
+
+
+class TargetNameNotProvided(DbtSugarException):
+    """Thrown when no `target:` entry is provided in the profiles.yml and not passed on CLI."""

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -29,6 +29,7 @@ class FlagParser:
         self.config_path: Path = Path(str())
         self.profiles_dir: Path = Path(str())
         self.is_dry_run: bool = False
+        self.target: str = str()
 
     def consume_cli_arguments(self, test_cli_args: List[str] = list()) -> None:
         if test_cli_args:
@@ -54,3 +55,4 @@ class FlagParser:
         if self.task == "doc":
             self.model = self.args.model
             self.schema = self.args.schema
+            self.target = self.args.target

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -5,6 +5,7 @@ from typing import List, Union
 
 from dbt_sugar.core._version import __version__
 from dbt_sugar.core.clients.dbt import DbtProfile
+from dbt_sugar.core.config.config import DbtSugarConfig
 from dbt_sugar.core.flags import FlagParser
 from dbt_sugar.core.logger import GLOBAL_LOGGER as logger
 from dbt_sugar.core.logger import log_manager
@@ -100,9 +101,14 @@ def handle(
     flag_parser = FlagParser(parser)
     flag_parser.consume_cli_arguments(test_cli_args=test_cli_args)
 
+    sugar_config = DbtSugarConfig(flag_parser)
+    sugar_config.load_config()
     # TODO: Feed project_name dynamically at run time from CLI or config.
     dbt_profile = DbtProfile(
-        project_name="default", target_name="dev", profiles_dir=flag_parser.profiles_dir
+        profile_name="default",
+        project_name="default",
+        target_name="dev",
+        profiles_dir=flag_parser.profiles_dir,
     )
 
     if flag_parser.log_level == "debug":

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -103,14 +103,16 @@ def handle(
 
     sugar_config = DbtSugarConfig(flag_parser)
     sugar_config.load_config()
-    dbt_project = DbtProject(
-        sugar_config.config.get("name", str()), sugar_config.config.get("path", str())
-    )
 
+    # TODO: Revise the index access here when we can support multiple dbt projects properly.
+    dbt_project = DbtProject(
+        sugar_config.config.get("dbt_projects", list())[0].get("name", str()),
+        sugar_config.config.get("dbt_projects", list())[0].get("path", str()),
+    )
+    dbt_project.read_project()
     # TODO: Feed project_name dynamically at run time from CLI or config.
     dbt_profile = DbtProfile(
         profile_name=dbt_project.profile_name,
-        # project_name="default",
         target_name="dev",
         profiles_dir=flag_parser.profiles_dir,
     )

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -70,8 +70,9 @@ document_sub_parser = sub_parsers.add_parser(
     "doc", parents=[base_subparser], help="Runs documentation and test enforement task."
 )
 document_sub_parser.set_defaults(cls=DocumentationTask, which="doc")
+# TODO: We shouldn't be requiring this if we have a `--model` format as it's considered bad practice
 document_sub_parser.add_argument(
-    "-m", "--model", help="Name of the dbt model to document", type=str, default=None
+    "-m", "--model", help="Name of the dbt model to document", type=str, default=None, required=True
 )
 document_sub_parser.add_argument(
     "-s",
@@ -85,6 +86,13 @@ document_sub_parser.add_argument(
     help="When provided the documentation task will not modify your files",
     action="store_true",
     default=False,
+)
+document_sub_parser.add_argument(
+    "-t",
+    "--target",
+    help="Which target from the dbt profile to load.",
+    type=str,
+    default=str(),
 )
 
 
@@ -110,10 +118,9 @@ def handle(
         sugar_config.config.get("dbt_projects", list())[0].get("path", str()),
     )
     dbt_project.read_project()
-    # TODO: Feed project_name dynamically at run time from CLI or config.
     dbt_profile = DbtProfile(
         profile_name=dbt_project.profile_name,
-        target_name="dev",
+        target_name=flag_parser.target,
         profiles_dir=flag_parser.profiles_dir,
     )
     dbt_profile.read_profile()

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -4,7 +4,7 @@ import sys
 from typing import List, Union
 
 from dbt_sugar.core._version import __version__
-from dbt_sugar.core.clients.dbt import DbtProfile
+from dbt_sugar.core.clients.dbt import DbtProfile, DbtProject
 from dbt_sugar.core.config.config import DbtSugarConfig
 from dbt_sugar.core.flags import FlagParser
 from dbt_sugar.core.logger import GLOBAL_LOGGER as logger
@@ -103,13 +103,18 @@ def handle(
 
     sugar_config = DbtSugarConfig(flag_parser)
     sugar_config.load_config()
+    dbt_project = DbtProject(
+        sugar_config.config.get("name", str()), sugar_config.config.get("path", str())
+    )
+
     # TODO: Feed project_name dynamically at run time from CLI or config.
     dbt_profile = DbtProfile(
-        profile_name="default",
-        project_name="default",
+        profile_name=dbt_project.profile_name,
+        # project_name="default",
         target_name="dev",
         profiles_dir=flag_parser.profiles_dir,
     )
+    dbt_profile.read_profile()
 
     if flag_parser.log_level == "debug":
         log_manager.set_debug()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,3 +76,6 @@ template = "changelog/_template.rst"
     directory = "misc"
     name = "Under The Hood/Misc"
     showcontent = true
+
+[tool.pytest.ini_options]
+markers = ["datafiles"]

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -64,13 +64,29 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
         config_filepath = Path(datafiles).joinpath("sugar_config_missing_default.yml")
 
     if is_missing_syrup:
-        cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "non_existant"]
+        cli_args = [
+            "doc",
+            "--config-path",
+            str(config_filepath),
+            "--syrup",
+            "non_existant",
+            "-m",
+            "test_model",
+        ]
     elif has_no_default_syrup:
-        cli_args = ["doc", "--config-path", str(config_filepath)]
+        cli_args = ["doc", "--config-path", str(config_filepath), "-m", "test_model"]
     elif is_missing_dbt_project:
-        cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "syrup_2"]
+        cli_args = [
+            "doc",
+            "--config-path",
+            str(config_filepath),
+            "--syrup",
+            "syrup_2",
+            "-m",
+            "test_model",
+        ]
     else:
-        cli_args = ["doc"]
+        cli_args = ["doc", "-m", "test_model"]
 
     flags = FlagParser(parser)
     flags.consume_cli_arguments(cli_args)

--- a/tests/dbt_client_test.py
+++ b/tests/dbt_client_test.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import pytest
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_read_project(datafiles):
+    from dbt_sugar.core.clients.dbt import DbtProject
+    from dbt_sugar.core.config.config import DbtSugarConfig
+    from dbt_sugar.core.flags import FlagParser
+    from dbt_sugar.core.main import parser
+
+    config_filepath = Path(datafiles).joinpath("sugar_config.yml")
+    cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "syrup_1"]
+
+    flag_parser = FlagParser(parser)
+    flag_parser.consume_cli_arguments(test_cli_args=cli_args)
+
+    sugar_config = DbtSugarConfig(flag_parser)
+    sugar_config.load_config()
+    print(f"the config {sugar_config.config}")
+    print(sugar_config.config.get("path"))
+
+    dbt_project = DbtProject(
+        project_name=sugar_config.config.get("dbt_projects", list())[0].get("name", str()),
+        project_dir=sugar_config.config.get("dbt_projects", list())[0].get("path", str()),
+    )
+    dbt_project.read_project()
+
+    assert dbt_project.profile_name == "dbt_sugar_test"

--- a/tests/dbt_client_test.py
+++ b/tests/dbt_client_test.py
@@ -13,7 +13,15 @@ def test_read_project(datafiles):
     from dbt_sugar.core.main import parser
 
     config_filepath = Path(datafiles).joinpath("sugar_config.yml")
-    cli_args = ["doc", "--config-path", str(config_filepath), "--syrup", "syrup_1"]
+    cli_args = [
+        "doc",
+        "--config-path",
+        str(config_filepath),
+        "--syrup",
+        "syrup_1",
+        "-m",
+        "test_project",
+    ]
 
     flag_parser = FlagParser(parser)
     flag_parser.consume_cli_arguments(test_cli_args=cli_args)

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -17,7 +17,7 @@ def __init_descriptions(params=None, dbt_profile=None):
 
 def test_load_dbt_credentials():
     profile = DbtProfile(
-        project_name="dbt_sugar_test_project",
+        profile_name="dbt_sugar_test",
         target_name="snowflake",
         profiles_dir=Path(FIXTURE_DIR).joinpath("profiles.yml"),
     )

--- a/tests/handle_test.py
+++ b/tests/handle_test.py
@@ -4,8 +4,7 @@ import pytest
 
 from dbt_sugar.core.task.doc import DocumentationTask
 
-TEST_PROFILES_DIR = Path(__file__).resolve().parent.joinpath("docker_postgres")
-# , "profiles.yml")
+TEST_PROFILES_DIR = Path(__file__).resolve().parent.joinpath("profiles.yml")
 
 
 @pytest.mark.parametrize(

--- a/tests/profile_test.py
+++ b/tests/profile_test.py
@@ -65,7 +65,7 @@ def test_read_profile(
     if target_name.startswith("bad_"):
         with pytest.raises(ValidationError):
             profile = DbtProfile(
-                project_name="dbt_sugar_test_project",
+                profile_name="dbt_sugar_test",
                 target_name=target_name,
                 profiles_dir=Path(datafiles).joinpath("profiles.yml"),
             )
@@ -73,7 +73,7 @@ def test_read_profile(
     elif is_invalid_target:
         with pytest.raises(ProfileParsingError):
             profile = DbtProfile(
-                project_name="dbt_sugar_test_project",
+                profile_name="dbt_sugar_test",
                 target_name=target_name,
                 profiles_dir=Path(datafiles).joinpath("profiles.yml"),
             )
@@ -81,7 +81,7 @@ def test_read_profile(
     elif is_missing_profile:
         with pytest.raises(DbtProfileFileMissing):
             profile = DbtProfile(
-                project_name="dbt_sugar_test_project",
+                profile_name="dbt_sugar_test",
                 target_name=target_name,
                 profiles_dir=Path(datafiles).joinpath("missing_profiles.yml"),
             )
@@ -89,14 +89,14 @@ def test_read_profile(
     elif is_bad_project:
         with pytest.raises(ProfileParsingError):
             profile = DbtProfile(
-                project_name="bad_project",
+                profile_name="bad_project",
                 target_name=target_name,
                 profiles_dir=Path(datafiles).joinpath("profiles.yml"),
             )
             profile.read_profile()
     else:
         profile = DbtProfile(
-            project_name="dbt_sugar_test_project",
+            profile_name="dbt_sugar_test",
             target_name=target_name,
             profiles_dir=Path(datafiles).joinpath("profiles.yml"),
         )

--- a/tests/profile_test.py
+++ b/tests/profile_test.py
@@ -114,6 +114,20 @@ def test_read_profile(
             assert profile.profile == expectations[target_name]
 
 
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test_read_profile_missing(datafiles):
+    from dbt_sugar.core.clients.dbt import DbtProfile
+    from dbt_sugar.core.exceptions import ProfileParsingError
+
+    with pytest.raises(ProfileParsingError):
+        profile = DbtProfile(
+            profile_name="tough shit it does not exist",
+            target_name=str(),
+            profiles_dir=Path(datafiles).joinpath("profiles.yml"),
+        )
+        profile.read_profile()
+
+
 @pytest.mark.parametrize(
     "profile_dict",
     [

--- a/tests/profiles.yml
+++ b/tests/profiles.yml
@@ -39,3 +39,4 @@ dbt_sugar_test:
       database: dbt_sugar
       password: magical_password
       schema: public
+  target: postgres

--- a/tests/profiles.yml
+++ b/tests/profiles.yml
@@ -1,4 +1,4 @@
-dbt_sugar_test_project:
+dbt_sugar_test:
   outputs:
     snowflake:
       type: snowflake
@@ -31,4 +31,11 @@ dbt_sugar_test_project:
       type: postgres
       user: dbt_sugar_test_user
       database: dbt_sugar
+      schema: public
+
+    dev:
+      type: postgres
+      user: dbt_sugar_test_user
+      database: dbt_sugar
+      password: magical_password
       schema: public

--- a/tests/test_yaml_helpers.py
+++ b/tests/test_yaml_helpers.py
@@ -44,7 +44,7 @@ def test_save_yaml(content, result):
     try:
         save_yaml(temp_file.name, content)
         yaml_content = open_yaml(Path(temp_file.name))
-        assert yaml_content == yaml.load(result)
+        assert yaml_content == yaml.safe_load(result)
     finally:
         os.unlink(temp_file.name)
         temp_file.close()


### PR DESCRIPTION
# Description
In order for `dbt-sugar` to know which profile to choose in order to connect to a database it needs to read the profile name from dbt's `dbt_project.yml`.

- The `sugar_config.yml` contains a list (currently we only support one entry) of dbt projects under scope. This list is made of dicts which contain `name` and `path` of dbt projects.
- The `DbtProject` object then loads the `dbt_project.yml` file from it's provided path and stores the `profile_name` which will be provided to `DbtProfile`.

This PR also implements reading the correct `target` profile from the `profiles.yml` by either getting it from `--target` on the CLI or from the `target:` yaml field in `profiles.yml`. Priority is given to the CLI argument as it is "closer" to the user.

# How was the change tested
I modified the unit tests to work and it seems good locally but I will wait to merge this branch until #51 is merged so that I can test this fully and with more corner cases.

# Issue Information
Partially addresses #38 because it introduces a necessary regression which renders `dbt-sugar` unable to have more than one dbt project in scope until we refactor how we store models associated to projects which will enable us to dynamically feed the right profile and credentials to the `DocumentationTask` db query step.

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
