### PR TITLE
ci: use `pull_request` instead of `pull_request_target` to prevent pwn

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -1,6 +1,6 @@
 name: Build, Test, Report Coverage
 
-on: ["push", "pull_request_target"]
+on: ["push", "pull_request"]
 
 jobs:
   build:
@@ -38,14 +38,10 @@ jobs:
         run: poetry install
         if: steps.cache.outputs.cache-hit != 'true'
 
-      - name: Run Tests and Coverage Report
-        run: |
-          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/
-
       - name: Upload coverage report to CodeCov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          env_vars: GITHUB_RUN_ID
           file: coverage-reports/coverage.xml
           flags: unittests
           name: codecov-umbrella


### PR DESCRIPTION
# Description

The `pull_request_target` trigger in GH actions exposes tokens: https://securitylab.github.com/research/github-actions-preventing-pwn-requests and https://www.youtube.com/watch?v=_fpXyS_i1xE

I had turned on this trigger to allow for forks to also be able to publish code coverage to codecov however they now (well for a while) provide tokenless report sending so this should be good.