### PR TITLE
feat: implement UI for tags

### DIFF
--- a/changelog/86.feature.rst
+++ b/changelog/86.feature.rst
@@ -1,0 +1,1 @@
+dbt-sugar will now ask users (and allow them) to add tags to their schema.yml files. PR for the backend flow `#85 <https://github.com/bitpicky/dbt-sugar/pull/85>`_.

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -271,7 +271,10 @@ class UserInputCollector:
 
     @classmethod
     def _document_undocumented_cols(
-        cls, question_payload: Sequence[Mapping[str, Any]], ask_for_tests: bool = True
+        cls,
+        question_payload: Sequence[Mapping[str, Any]],
+        ask_for_tests: bool = True,
+        ask_for_tags: bool = True,
     ) -> Mapping[str, Mapping[str, Union[str, List[str]]]]:
 
         results: Mapping[str, Mapping[str, Union[str, List[str]]]] = dict()
@@ -287,19 +290,24 @@ class UserInputCollector:
 
         if document_all_cols:
             results = cls._iterate_through_columns(
-                cols=columns_to_document, ask_for_tests=ask_for_tests
+                cols=columns_to_document, ask_for_tests=ask_for_tests, ask_for_tags=ask_for_tags
             )
         else:
             # get the list of columns from user
             columns_to_document = questionary.prompt(question_payload)
             results = cls._iterate_through_columns(
-                cols=columns_to_document["cols_to_document"], ask_for_tests=ask_for_tests
+                cols=columns_to_document["cols_to_document"],
+                ask_for_tests=ask_for_tests,
+                ask_for_tags=ask_for_tags,
             )
         return results
 
     @classmethod
     def _document_already_documented_cols(
-        cls, question_payload: Sequence[Mapping[str, Any]], ask_for_tests: bool = True
+        cls,
+        question_payload: Sequence[Mapping[str, Any]],
+        ask_for_tests: bool = True,
+        ask_for_tags: bool = True,
     ) -> Mapping[str, Mapping[str, Union[str, List[str]]]]:
         mutable_payload = copy.deepcopy(question_payload)
         mutable_payload = cast(Sequence[Dict[str, Any]], mutable_payload)
@@ -320,7 +328,9 @@ class UserInputCollector:
         if document_any_columns:
             columns_to_document = questionary.prompt(mutable_payload)
             _results = cls._iterate_through_columns(
-                cols=columns_to_document["cols_to_document"], ask_for_tests=ask_for_tests
+                cols=columns_to_document["cols_to_document"],
+                ask_for_tests=ask_for_tests,
+                ask_for_tags=ask_for_tags,
             )
 
             # remove description from col key

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -232,7 +232,7 @@ class UserInputCollector:
                     message="Would you like to add any tags?"
                 ).ask()
                 if wants_to_add_tags:
-                    tags = questionary.text(message="Prodive a comma-separated list of tags").ask()
+                    tags = questionary.text(message="Provide a comma-separated list of tags").ask()
                     tags = cls.__split_comma_separated_str(tags)
                     if tags:
                         results[column]["tags"] = tags

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -246,8 +246,7 @@ class UserInputCollector:
         _tags = []
         if isinstance(tags, str):
             _tags = tags.split(",")
-            if isinstance(tags, list):
-                _tags = [s.strip() for s in _tags]
+            _tags = [s.strip() for s in _tags]
             return _tags
         raise TypeError(f"Tags can only be strings. You provided a {type(tags)}")
 

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -207,5 +207,4 @@ def test__iterate_through_columns(mocker, question_payload, expected_results):
     )._iterate_through_columns(
         cols=question_payload["col_list"], ask_for_tests=question_payload["ask_for_tests"]
     )
-    print(results)
     assert results == expected_results

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -78,7 +78,10 @@ def test__document_model(mocker, question_payload, questionary_outputs, expected
                 "confirm_return": True,
                 "prompt_return": {"col_a": "Custom desc", "col_b": "Custom desc"},
             },
-            {"col_a": {"description": "Custom desc"}, "col_b": {"description": "Custom desc"}},
+            {
+                "col_a": {"description": "Custom desc", "tags": ["Custom desc"]},
+                "col_b": {"description": "Custom desc", "tags": ["Custom desc"]},
+            },
             id="document_all_undocumented",
         ),
         pytest.param(
@@ -131,7 +134,7 @@ def test__document_undocumented_columns(
                 "confirm_return": True,
                 "prompt_return": {"cols_to_document": ["col_a"]},
             },
-            {"col_a": {"description": "Custom desc"}},
+            {"col_a": {"description": "Custom desc", "tags": ["Custom desc"]}},
             id="document_some_documented_cols",
         ),
         pytest.param(
@@ -180,10 +183,18 @@ def test__document_already_documented_cols(
         pytest.param(
             {"col_list": ["column_a", "column_b"], "ask_for_tests": True},
             {
-                "column_a": {"description": "Dummy description", "tests": ["unique"]},
-                "column_b": {"description": "Dummy description", "tests": ["unique"]},
+                "column_a": {
+                    "description": "Dummy description",
+                    "tests": ["unique"],
+                    "tags": ["Dummy description"],
+                },
+                "column_b": {
+                    "description": "Dummy description",
+                    "tests": ["unique"],
+                    "tags": ["Dummy description"],
+                },
             },
-            id="document_columns_yes_test",
+            id="document_columns_yes_test_and_tags",
         ),
     ],
 )
@@ -196,4 +207,5 @@ def test__iterate_through_columns(mocker, question_payload, expected_results):
     )._iterate_through_columns(
         cols=question_payload["col_list"], ask_for_tests=question_payload["ask_for_tests"]
     )
+    print(results)
     assert results == expected_results


### PR DESCRIPTION
# Description
This code change adds support for tags addition.

When documenting a column a user will now be asked whether they want to add tags to this column. If they do, we ask them to provide a comma separated list of strings for those tags.

The UI API will return the following payload to the backend:
```python
{
    'col_a': {
    'description': 'Description for col a',
    'tests': ['unique'],
    'tags': ['PII']
    },
    'col_b': {'description': 'Description for col b'}
}
```

# How was the change tested
Unit tests were modified to account for and test for tag generation in the payload

# Issue Information
Closes #62

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
