### PR TITLE
regr: implement explicit error for multiple dbt projects

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -10,5 +10,5 @@ jobs:
     steps:
       - uses: seferov/pr-lint-action@master
         with:
-          title-regex: "^feat|fix|refactor|chore|docs|ci|style|release|revert|Bump|Update "
+          title-regex: "^feat|fix|refactor|chore|docs|ci|style|release|revert|regr|Bump|Update "
           title-regex-flags: "g"

--- a/changelog/93.feature.rst
+++ b/changelog/93.feature.rst
@@ -1,0 +1,1 @@
+Introduces a temporary (until next feature release --or maybe in a patch) regression which will restrict dbt-sugar to only be able to manage **one** dbt project instead of more as was originally intended and hinted at by the use of plural ``dbt_projects:`` entry in ``sugar_config.yml``.

--- a/dbt_sugar/core/exceptions.py
+++ b/dbt_sugar/core/exceptions.py
@@ -37,3 +37,7 @@ class MissingDbtProjects(DbtSugarException):
 
 class TargetNameNotProvided(DbtSugarException):
     """Thrown when no `target:` entry is provided in the profiles.yml and not passed on CLI."""
+
+
+class KnownRegressionError(DbtSugarException):
+    """Thrown when we want to warn users of a known regression or limitation that is not implemented."""

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -12,7 +12,13 @@ syrups:
     dbt_projects:
       - name: dwh
         path: path
-        excluded_tables:
-          - table_a
-      - name: prediction
-        path: path
+  # TODO: Remove this when we have dealt with this regression.
+  # ! REGRESSION
+  # - name: syrup_3
+  # dbt_projects:
+  # - name: dwh
+  # path: path
+  # excluded_tables:
+  # - table_a
+  # - name: prediction
+  # path: path


### PR DESCRIPTION
# Description
Implements an explicit error raising for the intentional regression proposed in [#92](https://github.com/bitpicky/dbt-sugar/issues/92)

TLDR: We cannot support (for now) having more than one dbt project under dbt-sugar's scope given the current backend design and we're making a concious choice to implement this regression for the time being so that we can get some testing and usage sonner.

Since the `sugar_config.yml` field that stores the dbt project information is pluralised we want to make sure people do not add multiple projects for now and expect it to work although it would otherwise silently ignore a bunch of projects.

# How was the change tested
I developed the feature via TDD so the unit test covers this feature.

# Issue Information
Does not implement or close any issue but is related to #92

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
