### PR TITLE
feat: implement test and tags deactivation

### DIFF
--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -28,6 +28,8 @@ class FlagParser:
         self.config_path: Path = Path(str())
         self.profiles_dir: Path = Path(str())
         self.is_dry_run: bool = False
+        self.no_tests: bool = False
+        self.no_tags: bool = False
         self.target: str = str()
         self.verbose: bool = False
 
@@ -56,3 +58,5 @@ class FlagParser:
             self.model = self.args.model
             self.schema = self.args.schema
             self.target = self.args.target
+            self.no_tests = self.args.no_tests
+            self.no_tags = self.args.no_tags

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -100,9 +100,23 @@ document_sub_parser.add_argument(
     type=str,
     default=str(),
 )
+document_sub_parser.add_argument(
+    "--no-tests",
+    help="When provided the documentation task will not ask for adding tests into the model.",
+    action="store_true",
+    default=False,
+)
 
+document_sub_parser.add_argument(
+    "--no-tags",
+    help="When provided the documentation task will not ask for adding TAGs into the model.",
+    action="store_true",
+    default=False,
+)
 
 # task handler
+
+
 def handle(
     parser: argparse.ArgumentParser,
     test_cli_args: List[str] = list(),

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -200,7 +200,11 @@ class DocumentationTask(BaseTask):
                 }
             ]
             user_input = UserInputCollector(
-                "undocumented_columns", undocumented_columns_payload
+                "undocumented_columns",
+                undocumented_columns_payload
+                # TODO: Add the functionality of tests and tags
+                # no_tests=self._flags.no_tests,
+                # no_tags=self._flags.no_tags,
             ).collect()
             self.column_update_payload.update(user_input)
 


### PR DESCRIPTION
# Description
Adding the ability to deactivate the tests and tags by parameter, deactivation means not ask the user for tests and tags when they are documenting a column.

# How was the change tested
Ran it in local.

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
