### PR TITLE
feat: allow tag and test skipping from CLI and sugar_config

### DIFF
--- a/changelog/101.feature.rst
+++ b/changelog/101.feature.rst
@@ -1,0 +1,3 @@
+Users can control whether dbt-sugar should ask to add tests or tags  via the following CLI arguments:
+- via CLI arguments on each run:  ``--ask-for-tests/--no-ask-for-tests`` and ``--ask-for-tags/--no-ask-for-tags`` or
+- globally per ``syrup`` in the ``sugar_config.yml`` via the following arguments: ``always_enforce_tests`` and ``always_add_tags``

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -29,6 +29,8 @@ class SyrupModel(BaseModel):
 
     name: str
     dbt_projects: List[DbtProjectsModel]
+    always_enforce_tests: Optional[bool] = True
+    always_add_tags: Optional[bool] = True
 
 
 class DefaultsModel(BaseModel):

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -1,7 +1,7 @@
 """Holds config for dbt-sugar."""
 
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel
 
@@ -51,6 +51,10 @@ class DbtSugarConfig:
     """dbt-sugar configuration class."""
 
     SUGAR_CONFIG_FILENAME = "sugar_config.yml"
+    CLI_OVERRIDE_FLAGS = [
+        {"cli_arg_name": "ask_for_tests", "maps_to": "always_enforce_tests"},
+        {"cli_arg_name": "ask_for_tags", "maps_to": "always_add_tags"},
+    ]
 
     def __init__(self, flags: FlagParser, max_dir_upwards_iterations: int = 4) -> None:
         """Constructor for DbtSugarConfig.
@@ -76,7 +80,8 @@ class DbtSugarConfig:
     def config(self):
         if self.config_model:
             logger.debug(f"Config model dict: {self.config_model.dict()}")
-            return self.config_model.dict()
+            config_dict = self._integrate_cli_flags(self.config_model.dict())
+            return config_dict
         raise AttributeError(f"{type(self).__name__} does not have a parsed config.")
 
     def load_and_validate_config_yaml(self) -> None:
@@ -165,6 +170,11 @@ class DbtSugarConfig:
                     f"Unable to find {self.SUGAR_CONFIG_FILENAME} in any nearby "
                     f"directories after {self._max_folder_iterations} iterations upwards."
                 )
+
+    def _integrate_cli_flags(self, config_dict: Dict[str, Any]):
+        for flag_dict in self.CLI_OVERRIDE_FLAGS:
+            config_dict[flag_dict["maps_to"]] = getattr(self._flags, flag_dict["cli_arg_name"])
+        return config_dict
 
     def load_config(self) -> None:
         self.locate_config()

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -28,6 +28,8 @@ class FlagParser:
         self.config_path: Path = Path(str())
         self.profiles_dir: Path = Path(str())
         self.is_dry_run: bool = False
+        self.no_tests: bool = False
+        self.no_tags: bool = False
         self.target: str = str()
         self.verbose: bool = False
 
@@ -56,3 +58,5 @@ class FlagParser:
             self.model = self.args.model
             self.schema = self.args.schema
             self.target = self.args.target
+            self.no_tests = self.args.no_tests
+            self.no_tags = self.args.no_tags

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -28,8 +28,8 @@ class FlagParser:
         self.config_path: Path = Path(str())
         self.profiles_dir: Path = Path(str())
         self.is_dry_run: bool = False
-        self.no_tests: bool = False
-        self.no_tags: bool = False
+        self.ask_for_tests: bool = True
+        self.ask_for_tags: bool = True
         self.target: str = str()
         self.verbose: bool = False
 
@@ -58,5 +58,6 @@ class FlagParser:
             self.model = self.args.model
             self.schema = self.args.schema
             self.target = self.args.target
-            self.no_tests = self.args.no_tests
-            self.no_tags = self.args.no_tags
+            # we reverse the flag so that we don't have double negatives later in the code
+            self.ask_for_tests = self.args.ask_for_tests
+            self.ask_for_tags = self.args.ask_for_tags

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -172,7 +172,7 @@ def handle(
         log_manager.set_debug()
 
     if flag_parser.task == "doc":
-        task: DocumentationTask = DocumentationTask(flag_parser, dbt_profile)
+        task: DocumentationTask = DocumentationTask(flag_parser, dbt_profile, sugar_config)
         # TODO: We actually need to change the behaviour of DocumentationTask to provide an interactive
         # dry run but for now this allows testing without side effects.
         # the current implementation upsets mypy also.

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -100,18 +100,36 @@ document_sub_parser.add_argument(
     type=str,
     default=str(),
 )
+# document_sub_parser.add_argument(
+
 document_sub_parser.add_argument(
-    "--no-tests",
-    help="When provided the documentation task will not ask for adding tests into the model.",
-    action="store_true",
-    default=False,
+    "--no-ask-tests",
+    help="When provided the documentation task will not ask for adding TAGs into the model.",
+    action="store_false",
+    dest="ask_for_tests",
 )
 
 document_sub_parser.add_argument(
-    "--no-tags",
-    help="When provided the documentation task will not ask for adding TAGs into the model.",
+    "--ask-tests",
+    help="When passed dbt-sugar will ask you if you want to add tests to your models.",
     action="store_true",
-    default=False,
+    dest="ask_for_tests",
+    default=True,
+)
+
+document_sub_parser.add_argument(
+    "--no-ask-tags",
+    help="When provided the documentation task will not ask for adding TAGs into the model.",
+    action="store_false",
+    dest="ask_for_tags",
+)
+
+document_sub_parser.add_argument(
+    "--ask-tags",
+    help="When passed dbt-sugar will ask you if you want to add tests to your models.",
+    action="store_true",
+    dest="ask_for_tags",
+    default=True,
 )
 
 # task handler

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -100,9 +100,23 @@ document_sub_parser.add_argument(
     type=str,
     default=str(),
 )
+document_sub_parser.add_argument(
+    "--no-tests",
+    help="When provided the documentation task will not ask for adding tests into the model.",
+    action="store_true",
+    default=False,
+)
 
+document_sub_parser.add_argument(
+    "--no-tags",
+    help="When provided the documentation task will not ask for adding TAGs into the model.",
+    action="store_true",
+    default=False,
+)
 
 # task handler
+
+
 def handle(
     parser: argparse.ArgumentParser,
     test_cli_args: List[str] = list(),

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from dbt_sugar.core.clients.dbt import DbtProfile
 from dbt_sugar.core.clients.yaml_helpers import open_yaml, save_yaml
+from dbt_sugar.core.config.config import DbtSugarConfig
 from dbt_sugar.core.connectors.postgres_connector import PostgresConnector
 from dbt_sugar.core.connectors.snowflake_connector import SnowflakeConnector
 from dbt_sugar.core.flags import FlagParser
@@ -27,11 +28,12 @@ class DocumentationTask(BaseTask):
     Holds methods and attrs necessary to orchestrate a model documentation task.
     """
 
-    def __init__(self, flags: FlagParser, dbt_profile: DbtProfile) -> None:
+    def __init__(self, flags: FlagParser, dbt_profile: DbtProfile, config: DbtSugarConfig) -> None:
         super().__init__()
         self.column_update_payload: Dict[str, Dict[str, Any]] = {}
         self._flags = flags
         self._dbt_profile = dbt_profile
+        self._sugar_config = config
 
     def load_dbt_credentials(self) -> Dict[str, str]:
         """Method to load the DBT profile credentials."""
@@ -202,8 +204,8 @@ class DocumentationTask(BaseTask):
             user_input = UserInputCollector(
                 "undocumented_columns",
                 undocumented_columns_payload,
-                ask_for_tests=self._flags.ask_for_tests,
-                ask_for_tags=self._flags.ask_for_tags,
+                ask_for_tests=self._sugar_config.config["always_enforce_tests"],
+                ask_for_tags=self._sugar_config.config["always_add_tags"],
             ).collect()
             self.column_update_payload.update(user_input)
 

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -201,10 +201,9 @@ class DocumentationTask(BaseTask):
             ]
             user_input = UserInputCollector(
                 "undocumented_columns",
-                undocumented_columns_payload
-                # TODO: Add the functionality of tests and tags
-                # no_tests=self._flags.no_tests,
-                # no_tags=self._flags.no_tags,
+                undocumented_columns_payload,
+                ask_for_tests=self._flags.ask_for_tests,
+                ask_for_tags=self._flags.ask_for_tags,
             ).collect()
             self.column_update_payload.update(user_input)
 

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -200,7 +200,11 @@ class DocumentationTask(BaseTask):
                 }
             ]
             user_input = UserInputCollector(
-                "undocumented_columns", undocumented_columns_payload
+                "undocumented_columns",
+                undocumented_columns_payload
+                # TODO: Add the functionality of tests and tags
+                # no_tests=self._flags.no_tests,
+                # no_tags=self._flags.no_tags,
             ).collect()
             self.column_update_payload.update(user_input)
 

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -79,8 +79,8 @@ def test__document_model(mocker, question_payload, questionary_outputs, expected
                 "prompt_return": {"col_a": "Custom desc", "col_b": "Custom desc"},
             },
             {
-                "col_a": {"description": "Custom desc", "tags": ["Custom desc"]},
-                "col_b": {"description": "Custom desc", "tags": ["Custom desc"]},
+                "col_a": {"description": "Custom desc"},
+                "col_b": {"description": "Custom desc"},
             },
             id="document_all_undocumented",
         ),
@@ -113,8 +113,11 @@ def test__document_undocumented_columns(
     mocker.patch("questionary.prompt", return_value=questionary_outputs["prompt_return"])
     mocker.patch("questionary.text", return_value=Question("Custom desc"))
     results = UserInputCollector(
-        question_type="undocumented_columns", question_payload=question_payload
-    )._document_undocumented_cols(question_payload=question_payload, ask_for_tests=False)
+        question_type="undocumented_columns",
+        question_payload=question_payload,
+        ask_for_tests=False,
+        ask_for_tags=False,
+    )._document_undocumented_cols(question_payload=question_payload)
     assert results == expected_results
 
 
@@ -134,7 +137,7 @@ def test__document_undocumented_columns(
                 "confirm_return": True,
                 "prompt_return": {"cols_to_document": ["col_a"]},
             },
-            {"col_a": {"description": "Custom desc", "tags": ["Custom desc"]}},
+            {"col_a": {"description": "Custom desc"}},
             id="document_some_documented_cols",
         ),
         pytest.param(
@@ -164,8 +167,11 @@ def test__document_already_documented_cols(
     mocker.patch("questionary.prompt", return_value=questionary_outputs["prompt_return"])
     mocker.patch("questionary.text", return_value=Question("Custom desc"))
     results = UserInputCollector(
-        question_type="undocumented_columns", question_payload=question_payload
-    )._document_already_documented_cols(question_payload=question_payload, ask_for_tests=False)
+        question_type="undocumented_columns",
+        question_payload=question_payload,
+        ask_for_tests=False,
+        ask_for_tags=False,
+    )._document_already_documented_cols(question_payload=question_payload)
     assert results == expected_results
 
 
@@ -203,8 +209,6 @@ def test__iterate_through_columns(mocker, question_payload, expected_results):
     mocker.patch("questionary.checkbox", return_value=Question(["unique"]))
     mocker.patch("questionary.confirm", return_value=Question(question_payload["ask_for_tests"]))
     results = UserInputCollector(
-        "undocumented_columns", question_payload=[]
-    )._iterate_through_columns(
-        cols=question_payload["col_list"], ask_for_tests=question_payload["ask_for_tests"]
-    )
+        "undocumented_columns", question_payload=[], ask_for_tests=question_payload["ask_for_tests"]
+    )._iterate_through_columns(cols=question_payload["col_list"])
     assert results == expected_results

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -55,8 +55,10 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
                 "name": "dbt_sugar_test",
                 "path": "./tests/test_dbt_project/dbt_sugar_test",
                 "excluded_tables": ["table_a"],
-            }
+            },
         ],
+        "always_add_tags": True,
+        "always_enforce_tests": True,
     }
 
     config_filepath = Path(datafiles).joinpath("sugar_config.yml")

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -173,3 +173,77 @@ def test_assert_only_one_dbt_project_in_scope(
     else:
         with pytest.raises(KnownRegressionError):
             _ = config.assert_only_one_dbt_project_in_scope()
+
+
+@pytest.mark.parametrize(
+    "test_and_flag_args, expectation",
+    [
+        pytest.param(
+            "",
+            {
+                "name": "syrup_1",
+                "dbt_projects": [
+                    {
+                        "name": "dbt_sugar_test",
+                        "path": "./tests/test_dbt_project/dbt_sugar_test",
+                        "excluded_tables": ["table_a"],
+                    }
+                ],
+                "always_enforce_tests": True,
+                "always_add_tags": True,
+            },
+            id="no_test_or_tag_override",
+        ),
+        pytest.param(
+            "--no-ask-tests",
+            {
+                "name": "syrup_1",
+                "dbt_projects": [
+                    {
+                        "name": "dbt_sugar_test",
+                        "path": "./tests/test_dbt_project/dbt_sugar_test",
+                        "excluded_tables": ["table_a"],
+                    }
+                ],
+                "always_enforce_tests": False,
+                "always_add_tags": True,
+            },
+            id="no_tests_on_cli",
+        ),
+        pytest.param(
+            "--no-ask-tags",
+            {
+                "name": "syrup_1",
+                "dbt_projects": [
+                    {
+                        "name": "dbt_sugar_test",
+                        "path": "./tests/test_dbt_project/dbt_sugar_test",
+                        "excluded_tables": ["table_a"],
+                    }
+                ],
+                "always_enforce_tests": True,
+                "always_add_tags": False,
+            },
+            id="no_tags_on_cli",
+        ),
+    ],
+)
+@pytest.mark.datafiles(FIXTURE_DIR)
+def test__integrate_cli_flags(datafiles, test_and_flag_args, expectation):
+    from dbt_sugar.core.config.config import DbtSugarConfig
+    from dbt_sugar.core.flags import FlagParser
+    from dbt_sugar.core.main import parser
+
+    config_filepath = Path(datafiles).joinpath("sugar_config.yml")
+    cli_args = ["doc", "-m", "test_model", "--config-path", str(config_filepath)]
+    if test_and_flag_args:
+        cli_args.append(test_and_flag_args)
+
+    fp = FlagParser(cli_parser=parser)
+    fp.consume_cli_arguments(test_cli_args=cli_args)
+
+    config = DbtSugarConfig(fp)
+    config.load_config()
+
+    remapped = config._integrate_cli_flags(config.config_model.dict())
+    assert remapped == expectation

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -1,4 +1,3 @@
-from argparse import Namespace
 from pathlib import Path, PosixPath
 from unittest.mock import call
 
@@ -11,8 +10,8 @@ from dbt_sugar.core.task.doc import DocumentationTask
 FIXTURE_DIR = Path(__file__).resolve().parent
 
 
-def __init_descriptions(params=None, dbt_profile=None):
-    doc_task = DocumentationTask(params, dbt_profile)
+def __init_descriptions(params=None, dbt_profile=None, config=None):
+    doc_task = DocumentationTask(params, dbt_profile, config)
     doc_task.dbt_definitions = {"columnA": "descriptionA", "columnB": "descriptionB"}
     return doc_task
 
@@ -130,7 +129,7 @@ def test_update_model_description_test_tags(mocker, content, model_name, ui_resp
     open_yaml = mocker.patch("dbt_sugar.core.task.base.open_yaml")
     save_yaml = mocker.patch("dbt_sugar.core.task.base.save_yaml")
     open_yaml.return_value = content
-    doc_task = DocumentationTask(None, None)
+    doc_task = DocumentationTask(None, None, None)
     doc_task.update_model_description_test_tags(Path("."), model_name, ui_response)
     save_yaml.assert_has_calls(result)
 
@@ -463,7 +462,10 @@ def test_document_columns(mocker):
         def ask(self):
             return self._return_value
 
-    doc_task = DocumentationTask(Namespace(ask_for_tags=True, ask_for_tests=True), None)
+    class MockDbtSugarConfig:
+        config = {"always_enforce_tests": True, "always_add_tags": True}
+
+    doc_task = DocumentationTask(None, None, MockDbtSugarConfig)
     doc_task.dbt_definitions = {"columnA": "descriptionA", "columnB": "descriptionB"}
     mocker.patch("questionary.prompt", return_value={"cols_to_document": ["columnA"]})
     mocker.patch("questionary.confirm", return_value=Question(False))

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from pathlib import Path, PosixPath
 from unittest.mock import call
 
@@ -462,7 +463,8 @@ def test_document_columns(mocker):
         def ask(self):
             return self._return_value
 
-    doc_task = __init_descriptions()
+    doc_task = DocumentationTask(Namespace(ask_for_tags=True, ask_for_tests=True), None)
+    doc_task.dbt_definitions = {"columnA": "descriptionA", "columnB": "descriptionB"}
     mocker.patch("questionary.prompt", return_value={"cols_to_document": ["columnA"]})
     mocker.patch("questionary.confirm", return_value=Question(False))
     mocker.patch(

--- a/tests/handle_test.py
+++ b/tests/handle_test.py
@@ -2,10 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from dbt_sugar.core.task.doc import DocumentationTask
-
 TEST_PROFILES_DIR = Path(__file__).resolve().parent
-# .joinpath("profiles.yml")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
+++ b/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
@@ -5,14 +5,9 @@ models:
     columns:
       - name: id
         description: The primary key for this table
-        tests:
-          - unique
-          - not_null
       - name: answer
         description:
-          description: answer col
-          tests:
-            - unique
+          description: No description for this column.
       - name: question
         description: No description for this column.
   - name: my_second_dbt_model

--- a/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
+++ b/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
@@ -9,7 +9,10 @@ models:
           - unique
           - not_null
       - name: answer
-        description: No description for this column.
+        description:
+          description: answer col
+          tests:
+            - unique
       - name: question
         description: No description for this column.
   - name: my_second_dbt_model

--- a/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
+++ b/tests/test_dbt_project/dbt_sugar_test/models/example/schema.yml
@@ -6,8 +6,7 @@ models:
       - name: id
         description: The primary key for this table
       - name: answer
-        description:
-          description: No description for this column.
+        description: No description for this column.
       - name: question
         description: No description for this column.
   - name: my_second_dbt_model


### PR DESCRIPTION
# Description
Gives users control over whether dbt-sugar will ask for test enforcement or tag addition. This is achieved in the following ways:

## CLI control
- users can pass `--ask-for-tests/--no-ask-for-tests` to call test enforcement or not
- users can pass `--ask-for-tags/--no-ask-for-tags` to call tag addition or not

## Sugar Config
- users can add `always_enforce_tests` to each `syrup` in the `sugar_config.yml`. This will make dbt-sugar **always** ask for tests. If users do not provide this field, it is turned on by default. If it is set to `false` users will **have** to add `--ask-for-tests` on each run on the CLI to trigger tests enforcement.
- users can add `always_add_tags` similarly to what is explained above but for tags. Same default behaviour as above.

## Precedence is given to CLI.
If a user has either (or both) of the `always_enforce_tests` and `always_add_tags` set to True in their `sugar_config.yml` but decide to call dbt-sugar with `--no-add-test` or `--no-add-tags`, test and tag additions will be turned off for that run only.

CLI > `sugar_config.yml` since it is "closer" to the user.

## Important Note
- This PR changes the contract of `DocumentationTask` because this class should be getting its source of truth on whether to ask for tests or not from the `DbtSugarConfig`. This config is the one that is responsible for doing magic with the flags.

# How was the change tested
Unit tests have been placed on the helper function with deals with the override of the config with the CLI and previously written tests on the documentation task were updated.

# Issue Information
Closes #81

# Checklist

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
