### PR TITLE
fix: do not add tags if user provided an empty string

### DIFF
--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -242,8 +242,8 @@ class UserInputCollector:
                 ).ask()
                 if wants_to_add_tags:
                     tags = questionary.text(message="Provide a comma-separated list of tags").ask()
-                    tags = self.__split_comma_separated_str(tags)
-                    if tags[0]:
+                    if tags:
+                        tags = self.__split_comma_separated_str(tags)
                         results[column]["tags"] = tags
             # remove the column if no info has been given (no tests, and no description).
             if not results[column]:

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -243,7 +243,7 @@ class UserInputCollector:
                 if wants_to_add_tags:
                     tags = questionary.text(message="Provide a comma-separated list of tags").ask()
                     tags = self.__split_comma_separated_str(tags)
-                    if tags:
+                    if len(tags) > 0:
                         results[column]["tags"] = tags
             # remove the column if no info has been given (no tests, and no description).
             if not results[column]:

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -243,7 +243,7 @@ class UserInputCollector:
                 if wants_to_add_tags:
                     tags = questionary.text(message="Provide a comma-separated list of tags").ask()
                     tags = self.__split_comma_separated_str(tags)
-                    if len(tags) > 0:
+                    if tags[0]:
                         results[column]["tags"] = tags
             # remove the column if no info has been given (no tests, and no description).
             if not results[column]:


### PR DESCRIPTION
# Description
The checking of the tags was incorrect because it was None, with the split it was a list of one empty element [""].

# How was the change tested
Ran it in local.

# Ticket Info
Resolves this comment: https://github.com/bitpicky/dbt-sugar/issues/124#issuecomment-793052758

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
