### PR TITLE
fix: add columns when the model doesn't have any

### DIFF
--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -254,6 +254,10 @@ class DocumentationTask(BaseTask):
         for model in content.get("models", []):
             if model["name"] == model_name:
                 for column in columns_sql:
+                    # Checking that the model have the columns attribute.
+                    if not model.get("columns", None):
+                        model["columns"] = []
+
                     columns = model.get("columns", [])
                     columns_names = [column["name"] for column in columns]
                     if column not in columns_names:

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -212,7 +212,7 @@ def test_is_model_in_schema_content(content, model_name, result):
 @pytest.mark.parametrize(
     "content, model_name, columns_sql, result",
     [
-        (
+        pytest.param(
             {
                 "models": [
                     {
@@ -232,6 +232,29 @@ def test_is_model_in_schema_content(content, model_name, result):
                             {"description": "descriptionA", "name": "columnA"},
                             {"description": "No description for this column.", "name": "columnC"},
                         ],
+                    }
+                ]
+            },
+        ),
+        pytest.param(
+            {
+                "models": [
+                    {
+                        "name": "testmodel",
+                    }
+                ]
+            },
+            "testmodel",
+            ["columnA", "columnB", "columnC"],
+            {
+                "models": [
+                    {
+                        "columns": [
+                            {"description": "descriptionA", "name": "columnA"},
+                            {"description": "descriptionB", "name": "columnB"},
+                            {"description": COLUMN_NOT_DOCUMENTED, "name": "columnC"},
+                        ],
+                        "name": "testmodel",
                     }
                 ]
             },

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -235,6 +235,7 @@ def test_is_model_in_schema_content(content, model_name, result):
                     }
                 ]
             },
+            id="update_columns_from_model",
         ),
         pytest.param(
             {
@@ -258,6 +259,7 @@ def test_is_model_in_schema_content(content, model_name, result):
                     }
                 ]
             },
+            id="update_columns_from_model_without_columns",
         ),
     ],
 )


### PR DESCRIPTION
# Description
Adds column entry list if the model doesn't have any in the schema.yml

# How was the change tested
Ran it in local.

# Ticket Info
Resolves this comment: https://github.com/bitpicky/dbt-sugar/issues/124#issuecomment-792289513

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
