### PR TITLE
fix: make failed test output more salient

### DIFF
--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -190,12 +190,13 @@ class DocumentationTask(BaseTask):
                         tests.remove(test)
                 progress.advance(test_checking_task)
 
-    def _generate_test_success_message(self, test_name: str, column_name: str, has_passed: bool):
+    @staticmethod
+    def _generate_test_success_message(test_name: str, column_name: str, has_passed: bool):
         if has_passed:
-            return f"The '{test_name}' test on [bold]{column_name}[/bold] [green]PASSED"
+            return f"The [bold]{test_name}[/bold] test on '{column_name}' [green]PASSED"
         return (
-            f"The '{test_name}' test on [bold]{column_name}[/bold] [red]FAILED[/red]. \nIt will not be added "
-            "to your schema.yml."
+            f"The [bold]{test_name}[/bold] test on '{column_name}' [red]FAILED[/red]. \n\t└[bold]It will not be added "
+            "to your schema.yml.[/bold]"
         )
 
     def document_columns(


### PR DESCRIPTION
# Description
As mentioned in #136 when a lot of tests pass the message that warns users that their test will not be added to the schema was a bit swamped and hard to notice.

Now the output will look like this:
```
[17:14:42] The unique test on 'customer_id' FAILED.                                                                                                                                                                                                                                            
                   └It will not be added to your schema.yml.  
```

# How was the change tested
Ran interactively.

# Issue Information
Closes #136

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
