### PR TITLE
refactor: use unsafe_ask() instead of ask() in prompts

### DIFF
--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -213,7 +213,7 @@ class UserInputCollector:
         for column in cols:
             description = questionary.text(
                 message=f"Column: '{column}': {DESCRIPTION_PROMPT_MESSAGE}"
-            ).ask()
+            ).unsafe_ask()
 
             if description:
                 results.update({column: {"description": description}})
@@ -226,12 +226,12 @@ class UserInputCollector:
             if self._ask_for_tests:
                 wants_to_add_tests = questionary.confirm(
                     message="Would you like to add any tests?"
-                ).ask()
+                ).unsafe_ask()
                 if wants_to_add_tests:
                     tests = questionary.checkbox(
                         message="Please select one or more tests from the list below",
                         choices=AVAILABLE_TESTS,
-                    ).ask()
+                    ).unsafe_ask()
                     if tests:
                         results[column]["tests"] = tests
 
@@ -239,9 +239,11 @@ class UserInputCollector:
             if self._ask_for_tags:
                 wants_to_add_tags = questionary.confirm(
                     message="Would you like to add any tags?"
-                ).ask()
+                ).unsafe_ask()
                 if wants_to_add_tags:
-                    tags = questionary.text(message="Provide a comma-separated list of tags").ask()
+                    tags = questionary.text(
+                        message="Provide a comma-separated list of tags"
+                    ).unsafe_ask()
                     if tags:
                         tags = self.__split_comma_separated_str(tags)
                         results[column]["tags"] = tags
@@ -291,7 +293,7 @@ class UserInputCollector:
                 "Do you want to document them all?"
             ),
             auto_enter=True,
-        ).ask()
+        ).unsafe_ask()
 
         if document_all_cols:
             results = self._iterate_through_columns(cols=columns_to_document)
@@ -321,7 +323,7 @@ class UserInputCollector:
         document_any_columns = questionary.confirm(
             message="Do you want to document any of the already documented columns in this model?",
             auto_enter=True,
-        ).ask()
+        ).unsafe_ask()
 
         if document_any_columns:
             columns_to_document = questionary.prompt(mutable_payload)

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -7,7 +7,7 @@ class Question:
     def __init__(self, return_value):
         self._return_value = return_value
 
-    def ask(self):
+    def unsafe_ask(self):
         return self._return_value
 
 

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -3,7 +3,6 @@ from unittest.mock import call
 
 import pytest
 
-from dbt_sugar.core.clients.dbt import DbtProfile
 from dbt_sugar.core.task.base import COLUMN_NOT_DOCUMENTED
 from dbt_sugar.core.task.doc import DocumentationTask
 
@@ -507,7 +506,7 @@ def test_document_columns(mocker):
         def __init__(self, return_value):
             self._return_value = return_value
 
-        def ask(self):
+        def unsafe_ask(self):
             return self._return_value
 
     class MockDbtSugarConfig:


### PR DESCRIPTION
# Description
In order to properly terminate the app when users do `ctrl + c` we need to use `unsafe_ask()` from `questionary` so that the `KeyboardInterrupt` is not escaped by questionary and it bubbles up in our app scope so we can make the app do what we need in terms of cleaning if a user chooses to abort.

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information
Resolves #142

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
