### PR TITLE
fix: change model prompt question based on doc status

### DIFF
--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -34,7 +34,7 @@ class AuditTask(BaseTask):
             logger.info(f"Running audit of model [bold magenta]{self.model_name}.[/bold magenta]\n")
             path_file, schema_exists = self.find_model_in_dbt(self.model_name)
             if not path_file:
-                logger.info("Could not find the Model in the DBT project")
+                logger.info(f"Could not find {self.model_name} in the project at {self.dbt_path}")
                 return 1
             if not schema_exists:
                 logger.info("The model is not documented.")

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -1,6 +1,6 @@
 """Document Task module."""
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from rich.console import Console
 from rich.progress import BarColumn, Progress

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -59,7 +59,9 @@ class DocumentationTask(BaseTask):
             return self.orchestrate_model_documentation(schema, model, columns_sql)
         return 1
 
-    def change_model_description(self, content: Dict[str, Any], model_name: str) -> Dict[str, Any]:
+    def change_model_description(
+        self, content: Dict[str, Any], model_name: str, is_already_documented: bool = False
+    ) -> Dict[str, Any]:
         """Updates the model description from a schema.yaml.
 
         Args:
@@ -69,11 +71,14 @@ class DocumentationTask(BaseTask):
         Returns:
             Dict[str, Any]: Schema.yml content updated.
         """
+        message = f"Do you want to write a description for {model_name}"
+        if is_already_documented:
+            message = f"Do you want to change the model description of {model_name}"
         model_doc_payload: List[Mapping[str, Any]] = [
             {
                 "type": "confirm",
                 "name": "wants_to_document_model",
-                "message": f"Do you want to change the model description of {model_name}",
+                "message": message,
                 "default": True,
             },
             {
@@ -115,8 +120,8 @@ class DocumentationTask(BaseTask):
             )
         if schema_exists:
             content = open_yaml(path)
-        content = self.process_model(content, model_name, columns_sql)
-        content = self.change_model_description(content, model_name)
+        content, is_already_documented = self.process_model(content, model_name, columns_sql)
+        content = self.change_model_description(content, model_name, is_already_documented)
         save_yaml(path, content)
 
         not_documented_columns = self.get_not_documented_columns(content, model_name)
@@ -256,7 +261,7 @@ class DocumentationTask(BaseTask):
         Returns:
             Dict[str, Any]: with the content of the schema.yml with the model created.
         """
-        logger.info(f"The model '{model_name}' has not been docummented yet. Creating a new entry.")
+        logger.info(f"The model '{model_name}' has not been documented yet. Creating a new entry.")
         columns = []
         for column_sql in columns_sql:
             description = self.get_column_description_from_dbt_definitions(column_sql)
@@ -274,7 +279,7 @@ class DocumentationTask(BaseTask):
 
     def process_model(
         self, content: Optional[Dict[str, Any]], model_name: str, columns_sql: List[str]
-    ) -> Dict[str, Any]:
+    ) -> Tuple[Dict[str, Any], bool]:
         """Method to update/create a model entry in the schema.yml.
 
         Args:
@@ -283,6 +288,8 @@ class DocumentationTask(BaseTask):
         """
         if self.is_model_in_schema_content(content, model_name) and content:
             content = self.update_model(content, model_name, columns_sql)
+            is_already_documented = True
         else:
             content = self.create_new_model(content, model_name, columns_sql)
-        return content
+            is_already_documented = False
+        return content, is_already_documented

--- a/tests/audit_task_test.py
+++ b/tests/audit_task_test.py
@@ -1,4 +1,3 @@
-from argparse import ArgumentParser
 from pathlib import Path
 from unittest.mock import call
 

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -463,9 +463,9 @@ def test_get_not_documented_columns(content, model_name, result):
 
 
 @pytest.mark.parametrize(
-    "content, model_name, result",
+    "content, model_name, is_already_documented, result",
     [
-        (
+        pytest.param(
             {
                 "models": [
                     {
@@ -476,6 +476,7 @@ def test_get_not_documented_columns(content, model_name, result):
                 ]
             },
             "testmodel",
+            True,
             {
                 "models": [
                     {
@@ -485,8 +486,9 @@ def test_get_not_documented_columns(content, model_name, result):
                     }
                 ]
             },
+            id="model already in schema.yml with no columns",
         ),
-        (
+        pytest.param(
             {
                 "models": [
                     {
@@ -496,6 +498,7 @@ def test_get_not_documented_columns(content, model_name, result):
                 ]
             },
             "testmodel",
+            False,
             {
                 "models": [
                     {
@@ -505,10 +508,11 @@ def test_get_not_documented_columns(content, model_name, result):
                     }
                 ]
             },
+            id="model not already present in schema.yml",
         ),
     ],
 )
-def test_change_model_description(mocker, content, model_name, result):
+def test_change_model_description(mocker, content, model_name, is_already_documented, result):
     doc_task = __init_descriptions()
     mocker.patch(
         "questionary.prompt",
@@ -517,7 +521,7 @@ def test_change_model_description(mocker, content, model_name, result):
             "model_description": "New description for the model.",
         },
     )
-    assert doc_task.change_model_description(content, model_name) == result
+    assert doc_task.change_model_description(content, model_name, is_already_documented) == result
 
 
 def test_document_columns(mocker):

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -1,5 +1,5 @@
 defaults:
-  syrup: jaffle_shop
+  syrup: syrup_1
   target: dev
 syrups:
   - name: syrup_1

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -1,5 +1,5 @@
 defaults:
-  syrup: syrup_1
+  syrup: jaffle_shop
   target: dev
 syrups:
   - name: syrup_1

--- a/tests/test_dbt_project/jaffle_shop/models/marts/core/schema.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/marts/core/schema.yml
@@ -24,26 +24,3 @@ models:
         description: Count of the number of orders a customer has placed
       - name: total_order_amount
         description: Total value (AUD) of a customer's orders
-  - name: fct_orders
-    description: No description for this model.
-    columns:
-      - name: order_id
-        description: Unique order identifier increasing integer
-      - name: customer_id
-        description: Identifier of a customer. PK of the dim_company model
-      - name: order_date
-        description: No description for this column.
-      - name: status
-        description:
-          Orders can be in different statuses such as pending, refunded, confirmed etc. This column
-          contains this piece of information.
-      - name: credit_card_amount
-        description: No description for this column.
-      - name: coupon_amount
-        description: No description for this column.
-      - name: bank_transfer_amount
-        description: No description for this column.
-      - name: gift_card_amount
-        description: No description for this column.
-      - name: amount
-        description: No description for this column.


### PR DESCRIPTION
# Description
The model-level description prompt was always saying "do you want to change the model description" but that could lead to confusion when the user documents a model for the first time and there is no description to change.

# How was the change tested
Tested interactively and added unit test case for is_already_documented variable

# Issue Information
Resolves #135

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
