### PR TITLE
feat: add try-except for unsafe

### DIFF
--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -116,15 +116,20 @@ class DocumentationTask(BaseTask):
         if schema_exists:
             content = open_yaml(path)
         content = self.process_model(content, model_name, columns_sql)
-        content = self.change_model_description(content, model_name)
+
+        try:
+            content = self.change_model_description(content, model_name)
+
+            not_documented_columns = self.get_not_documented_columns(content, model_name)
+            self.document_columns(not_documented_columns, "undocumented_columns")
+
+            documented_columns = self.get_documented_columns(content, model_name)
+            self.document_columns(documented_columns, "documented_columns")
+        except KeyboardInterrupt:
+            logger.info("The user has exit the program, not saving the changes.")
+            return 0
+
         save_yaml(path, content)
-
-        not_documented_columns = self.get_not_documented_columns(content, model_name)
-        self.document_columns(not_documented_columns, "undocumented_columns")
-
-        documented_columns = self.get_documented_columns(content, model_name)
-        self.document_columns(documented_columns, "documented_columns")
-
         self.check_tests(schema, model_name)
         self.update_model_description_test_tags(path, model_name, self.column_update_payload)
         # Method to update the descriptions in all the schemas.yml

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -126,7 +126,7 @@ class DocumentationTask(BaseTask):
             documented_columns = self.get_documented_columns(content, model_name)
             self.document_columns(documented_columns, "documented_columns")
         except KeyboardInterrupt:
-            logger.info("The user has exit the program, not saving the changes.")
+            logger.info("dbt-sugar doc was cancelled by the user, all changes will be discarded.")
             return 0
 
         save_yaml(path, content)


### PR DESCRIPTION
# Description
If the user does a control+C during the flow we are able to exit with success without saving anything.

# How was the change tested
Ran it in local.

<img width="845" alt="Screenshot 2021-03-22 at 18 49 58" src="https://user-images.githubusercontent.com/16565856/112035059-79f17580-8b3f-11eb-8847-bf8f3ce65de5.png">


# Issue Information
https://github.com/bitpicky/dbt-sugar/issues/140

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
