### PR TITLE
feat: adding ordering into saving content

### DIFF
--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -95,7 +95,16 @@ class DocumentationTask(BaseTask):
                     model["description"] = user_input["model_description"]
         return content
 
-    def order_by_dict(self, model):
+    def move_name_and_description_to_first_position(self, model: Dict[str, Any]):
+        """
+        Move keys name and description to the beginning of the dictionary.
+
+        Args:
+            model (Dict[str, Any]): Name of the model to document.
+
+        Returns:
+            Dict[str, Any]: with the keys name and description in the begining of the dictionary.
+        """
         ordered_dict = OrderedDict(model)
         ordered_dict.move_to_end("description", last=False)
         ordered_dict.move_to_end("name", last=False)
@@ -116,7 +125,9 @@ class DocumentationTask(BaseTask):
         """
         for i, model in enumerate(content_yml.get("models", {})):
             # Adding name and description in the first positions of a model.
-            content_yml["models"][i] = self.order_by_dict(content_yml["models"][i])
+            content_yml["models"][i] = self.move_name_and_description_to_first_position(
+                content_yml["models"][i]
+            )
 
             # Sorting columns names in alphabetical order.
             if model.get("columns", None):

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -105,6 +105,7 @@ class DocumentationTask(BaseTask):
         Returns:
             Dict[str, Any]: with the keys name and description in the begining of the dictionary.
         """
+        # DEPRECATION: Drop ordered dict when dropping python 3.6 support
         ordered_dict = OrderedDict(model)
         ordered_dict.move_to_end("description", last=False)
         ordered_dict.move_to_end("name", last=False)

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -1,4 +1,5 @@
 """Document Task module."""
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
@@ -94,6 +95,39 @@ class DocumentationTask(BaseTask):
                     model["description"] = user_input["model_description"]
         return content
 
+    def order_by_dict(self, model):
+        ordered_dict = OrderedDict(model)
+        ordered_dict.move_to_end("description", last=False)
+        ordered_dict.move_to_end("name", last=False)
+        return dict(ordered_dict)
+
+    def order_schema_yml(self, content_yml: Dict[str, Any]):
+        """
+        Order the content from a schema.yml. Will order:
+
+            - The schema.yml content in alphabetical order.
+            - The models in alphabetical order.
+            - The columns from each model in alphabetical order.
+
+        Args:
+            content_yml (Dict[str, Any]): schema yml content to order.
+        Returns:
+            content_yml (Dict[str, Any]): schema yml content with the content ordered.
+        """
+        for i, model in enumerate(content_yml.get("models", {})):
+            # Adding name and description in the first positions of a model.
+            content_yml["models"][i] = self.order_by_dict(content_yml["models"][i])
+
+            # Sorting columns names in alphabetical order.
+            if model.get("columns", None):
+                content_yml["models"][i]["columns"] = sorted(
+                    model["columns"],
+                    key=lambda k: k["name"].lower(),
+                )
+        # Sorting models names in alphabetical order.
+        content_yml["models"] = sorted(content_yml["models"], key=lambda k: k["name"].lower())
+        return content_yml
+
     def orchestrate_model_documentation(
         self, schema: str, model_name: str, columns_sql: List[str]
     ) -> int:
@@ -134,7 +168,7 @@ class DocumentationTask(BaseTask):
             logger.info("The user has exited the doc task, all changes have been discarded.")
             return 0
 
-        save_yaml(path, content)
+        save_yaml(path, self.order_schema_yml(content))
         self.check_tests(schema, model_name)
         self.update_model_description_test_tags(path, model_name, self.column_update_payload)
         # Method to update the descriptions in all the schemas.yml

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -568,3 +568,132 @@ def test_find_model_in_dbt(model_name, path_model, schema_exists):
     path_file, schema = doc_task.find_model_in_dbt(model_name)
     assert path_file == path_model
     assert schema == schema_exists
+
+
+@pytest.mark.parametrize(
+    "content, result",
+    [
+        pytest.param(
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "dim_company",
+                        "description": "asdads",
+                        "columns": [
+                            {"name": "id", "description": "dsadasd"},
+                            {"name": "name", "description": "No description for this column."},
+                            {"name": "age", "description": "No description for this column."},
+                            {
+                                "name": "address",
+                                "description": "No description for this column.",
+                                "tests": ["not_null"],
+                            },
+                            {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                        ],
+                    }
+                ],
+            },
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "dim_company",
+                        "description": "asdads",
+                        "columns": [
+                            {
+                                "name": "address",
+                                "description": "No description for this column.",
+                                "tests": ["not_null"],
+                            },
+                            {"name": "age", "description": "No description for this column."},
+                            {"name": "id", "description": "dsadasd"},
+                            {"name": "name", "description": "No description for this column."},
+                            {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                        ],
+                    }
+                ],
+            },
+            id="reordering_columns",
+        ),
+        pytest.param(
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "dim_company",
+                        "description": "asdads",
+                        "columns": [],
+                    },
+                    {
+                        "name": "a_dim_company",
+                        "description": "asdads",
+                        "columns": [],
+                    },
+                ],
+            },
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "a_dim_company",
+                        "description": "asdads",
+                        "columns": [],
+                    },
+                    {
+                        "name": "dim_company",
+                        "description": "asdads",
+                        "columns": [],
+                    },
+                ],
+            },
+            id="reordering_models_names",
+        ),
+        pytest.param(
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "dim_company",
+                        "columns": [
+                            {"name": "id", "description": "dsadasd"},
+                            {"name": "name", "description": "No description for this column."},
+                            {"name": "age", "description": "No description for this column."},
+                            {
+                                "name": "address",
+                                "description": "No description for this column.",
+                                "tests": ["not_null"],
+                            },
+                            {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                        ],
+                        "description": "asdads",
+                    }
+                ],
+            },
+            {
+                "version": 2,
+                "models": [
+                    {
+                        "name": "dim_company",
+                        "description": "asdads",
+                        "columns": [
+                            {
+                                "name": "address",
+                                "description": "No description for this column.",
+                                "tests": ["not_null"],
+                            },
+                            {"name": "age", "description": "No description for this column."},
+                            {"name": "id", "description": "dsadasd"},
+                            {"name": "name", "description": "No description for this column."},
+                            {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                        ],
+                    }
+                ],
+            },
+            id="reordering_description_field",
+        ),
+    ],
+)
+def test_order_schema_yml(content, result):
+    doc_task = __init_descriptions()
+    assert doc_task.order_schema_yml(content) == result

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -697,3 +697,46 @@ def test_find_model_in_dbt(model_name, path_model, schema_exists):
 def test_order_schema_yml(content, result):
     doc_task = __init_descriptions()
     assert doc_task.order_schema_yml(content) == result
+
+
+@pytest.mark.parametrize(
+    "content, result",
+    [
+        pytest.param(
+            {
+                "columns": [
+                    {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                    {
+                        "name": "address",
+                        "description": "No description for this column.",
+                        "tests": ["not_null"],
+                    },
+                    {"name": "age", "description": "No description for this column."},
+                    {"name": "id", "description": "dsadasd"},
+                    {"name": "name", "description": "No description for this column."},
+                ],
+                "description": "qweqew",
+                "name": "dim_company",
+            },
+            {
+                "name": "dim_company",
+                "description": "qweqew",
+                "columns": [
+                    {"name": "salary", "description": "hey.", "tests": ["unique"]},
+                    {
+                        "name": "address",
+                        "description": "No description for this column.",
+                        "tests": ["not_null"],
+                    },
+                    {"name": "age", "description": "No description for this column."},
+                    {"name": "id", "description": "dsadasd"},
+                    {"name": "name", "description": "No description for this column."},
+                ],
+            },
+            id="move_name_description_to_beginning",
+        ),
+    ],
+)
+def test_move_name_and_description_to_first_position(content, result):
+    doc_task = __init_descriptions()
+    assert doc_task.move_name_and_description_to_first_position(content) == result


### PR DESCRIPTION
# Description
Ensures that the model description is always the first element of the model dictionary in the schema.yml

# How was the change tested
Ran it in local.

# Issue Information
Resolves #124 

(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
