### PR TITLE
feat: not print anything if they are not columns

### DIFF
--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -66,7 +66,9 @@ class AuditTask(BaseTask):
         columns = self.dbt_tests.get(self.model_name)
 
         if not columns:
-            logger.info(f"Not able to get the test statistics for the model {self.model_name}")
+            logger.info(
+                f"There is not documentation for the model {self.model_name}, you might need to run dbt-sugar doc."
+            )
             return
 
         for column in columns:
@@ -101,10 +103,15 @@ class AuditTask(BaseTask):
                 model_name=self.model_name,
             )
         )
+        number_columns = number_documented_columns + number_not_documented_columns
+
+        # This means that they are not columns, and we want to skip the printing.
+        if number_columns == 0:
+            return
 
         percentage_not_documented_columns = self.calculate_coverage_percentage(
             number_failures=number_not_documented_columns,
-            total=(number_documented_columns + number_not_documented_columns),
+            total=number_columns,
         )
 
         data = self.print_nicely_the_data(

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -67,7 +67,8 @@ class AuditTask(BaseTask):
 
         if not columns:
             logger.info(
-                f"There is not documentation for the model {self.model_name}, you might need to run dbt-sugar doc."
+                f"""There is not documentation for the model '{self.model_name}',
+                you might need to run `dbt-sugar doc` first."""
             )
             return
 


### PR DESCRIPTION
# Description
Fixing the message to be more clear, and not printing statistics table if they are not columns.

# How was the change tested
Ran it in local.

<img width="743" alt="Screenshot 2021-03-22 at 22 14 15" src="https://user-images.githubusercontent.com/16565856/112059327-00b44b80-8b5c-11eb-85d5-ec8dd3f01c6a.png">


# Issue Information
Resolves #158 

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
