### PR TITLE
refactor: :sparkles: improve audit look

### DIFF
--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -105,7 +105,7 @@ class AuditTask(BaseTask):
         )
 
         self.create_table(
-            title="Test Coverage", columns=["untested columns", "% coverage"], data=data
+            title="Test Coverage", columns=["Untested Columns", r"% coverage"], data=data
         )
 
     def get_model_column_description_coverage(self) -> None:
@@ -138,14 +138,12 @@ class AuditTask(BaseTask):
         )
 
         self.create_table(
-            title="Documentation Coverage", columns=["undocument columns", "% coverage"], data=data
+            title="Documentation Coverage", columns=["Undocument Columns", r"% coverage"], data=data
         )
 
     def print_nicely_the_data(self, data: List[str], total: str) -> Dict[str, str]:
         """
-        This method to transform a list into a dictionary with the data
-
-        as the keys and the total as the last element value.
+        Transforms a list into a dictionary (key: column, value: coverahe) total is appended at the end.
 
         Args:
             data (List): list of data to modify.
@@ -154,9 +152,10 @@ class AuditTask(BaseTask):
             Dict[str, str]: with a dictionary with the data as keys and
             the total as a value but only for the last element in the list.
         """
-        return {
-            (column): (str(total) if i == (len(data) - 1) else "") for i, column in enumerate(data)
-        }
+        reshaped_data = {column: "" for column in data}
+        reshaped_data[""] = ""
+        reshaped_data["Total"] = total
+        return reshaped_data
 
     def create_table(self, title: str, columns: List[str], data: Dict[str, str]) -> None:
         """

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -152,10 +152,12 @@ class AuditTask(BaseTask):
             Dict[str, str]: with a dictionary with the data as keys and
             the total as a value but only for the last element in the list.
         """
-        reshaped_data = {column: "" for column in data}
-        reshaped_data[""] = ""
-        reshaped_data["Total"] = total
-        return reshaped_data
+        if data:
+            reshaped_data = {column: "" for column in data}
+            reshaped_data[""] = ""
+            reshaped_data["Total"] = total
+            return reshaped_data
+        return {}
 
     def create_table(self, title: str, columns: List[str], data: Dict[str, str]) -> None:
         """

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -143,7 +143,7 @@ class AuditTask(BaseTask):
 
     def print_nicely_the_data(self, data: List[str], total: str) -> Dict[str, str]:
         """
-        Transforms a list into a dictionary (key: column, value: coverahe) total is appended at the end.
+        Transforms a list into a dictionary (key: column, value: coverahe) total is at the end.
 
         Args:
             data (List): list of data to modify.

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -57,6 +57,23 @@ class AuditTask(BaseTask):
         self.get_project_column_description_coverage()
         self.get_project_test_coverage()
 
+    def calculate_coverage_percentage(self, misses: int, total: int) -> str:
+        """
+        Method to calculate the percentage of coverage.
+
+        Args:
+            number_failures (int): With the number of failures.
+            total (int): With the number of total cases.
+
+        Returns:
+            str: with the calculation of the percentage.
+        """
+        if total == 0:
+            return "0.0"
+
+        percentage_failure = round((1 - (misses / total)) * 100, 1)
+        return str(percentage_failure)
+
     def get_model_test_coverage(self) -> None:
         """Method to get the tests coverage from a specific model."""
         # Init variables
@@ -80,7 +97,7 @@ class AuditTask(BaseTask):
                 untested_columns.append(column["name"])
 
         percentage_not_tested_columns = self.calculate_coverage_percentage(
-            number_failures=model_columns_without_tests, total=model_number_columns
+            misses=model_columns_without_tests, total=model_number_columns
         )
 
         data = self.print_nicely_the_data(
@@ -112,7 +129,7 @@ class AuditTask(BaseTask):
             return
 
         percentage_not_documented_columns = self.calculate_coverage_percentage(
-            number_failures=number_not_documented_columns,
+            misses=number_not_documented_columns,
             total=number_columns,
         )
 
@@ -181,17 +198,17 @@ class AuditTask(BaseTask):
                     model_columns_without_tests += 1
 
             print_statistics[model_name] = self.calculate_coverage_percentage(
-                number_failures=model_columns_without_tests, total=model_number_columns
+                misses=model_columns_without_tests, total=model_number_columns
             )
 
         print_statistics[""] = ""
-        print_statistics["TOTAL"] = self.calculate_coverage_percentage(
-            number_failures=number_columns_without_tests, total=total_number_columns
+        print_statistics["Total"] = self.calculate_coverage_percentage(
+            misses=number_columns_without_tests, total=total_number_columns
         )
 
         self.create_table(
             title="Test Coverage",
-            columns=["Model Name", "% coverage"],
+            columns=["Model Name", r"% coverage"],
             data=print_statistics,
         )
 
@@ -216,35 +233,18 @@ class AuditTask(BaseTask):
             )
 
             print_statistics[model_name] = self.calculate_coverage_percentage(
-                number_failures=number_not_documented_columns,
+                misses=number_not_documented_columns,
                 total=(number_documented_columns + number_not_documented_columns),
             )
 
         print_statistics[""] = ""
-        print_statistics["TOTAL"] = self.get_project_total_test_coverage()
+        print_statistics["Total"] = self.get_project_total_test_coverage()
 
         self.create_table(
             title="Documentation Coverage",
-            columns=["Model Name", "% coverage"],
+            columns=["Model Name", r"% coverage"],
             data=print_statistics,
         )
-
-    def calculate_coverage_percentage(self, number_failures: int, total: int) -> str:
-        """
-        Method to calculate the percentage of coverage.
-
-        Args:
-            number_failures (int): With the number of failures.
-            total (int): With the number of total cases.
-
-        Returns:
-            str: with the calculation of the percentage.
-        """
-        if total == 0:
-            return "0.0"
-
-        percentage_failure = round((1 - (number_failures / total)) * 100, 2)
-        return str(percentage_failure)
 
     def get_project_total_test_coverage(self) -> str:
         """
@@ -262,6 +262,6 @@ class AuditTask(BaseTask):
             number_of_columns += 1
 
         return self.calculate_coverage_percentage(
-            number_failures=number_not_documented_columns,
+            misses=number_not_documented_columns,
             total=number_of_columns,
         )

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
+from rich import box
 from rich.console import Console
 from rich.table import Table
 
@@ -67,8 +68,8 @@ class AuditTask(BaseTask):
 
         if not columns:
             logger.info(
-                f"""There is not documentation for the model '{self.model_name}',
-                you might need to run `dbt-sugar doc` first."""
+                f"There is not documentation for the model '{self.model_name}' "
+                "you might need to run `dbt-sugar doc` first."
             )
             return
 
@@ -149,18 +150,18 @@ class AuditTask(BaseTask):
             columns (List[str]): List of columns that the table is going to have.
             data (Dict[str, str]): with the rows that we want to print.
         """
-        table = Table(title)
+        table = Table(title=title, box=box.SIMPLE)
         for column in columns:
             table.add_column(column, justify="right", style="bright_yellow", no_wrap=True)
 
         for model, percentage in data.items():
-            table.add_row("", model, percentage)
+            table.add_row(model, percentage)
 
         console = Console()
         console.print(table)
 
     def get_project_test_coverage(self) -> None:
-        """Method to get the model tests coverage per model in a DBT project."""
+        """Method to get the model tests coverage per model in a dbt project."""
         print_statistics = {}
         total_number_columns = 0
         number_columns_without_tests = 0

--- a/tests/audit_task_test.py
+++ b/tests/audit_task_test.py
@@ -24,7 +24,7 @@ def __init_descriptions():
 
     audit_task = AuditTask(flag_parser, FIXTURE_DIR)
     audit_task.dbt_definitions = {"columnA": "descriptionA", "columnB": "descriptionB"}
-    audit_task.repository_path = "tests/test_dbt_project/"
+    audit_task.repository_path = Path("tests/test_dbt_project/")
     return audit_task
 
 
@@ -94,13 +94,13 @@ def test_calculate_coverage_percentage(failures, total, result):
         pytest.param(
             ["column_A"],
             "10.0",
-            {"column_A": "10.0"},
+            {"column_A": "", "": "", "Total": "10.0"},
             id="check_results_with_one_data_element",
         ),
         pytest.param(
             ["column_A", "column_B"],
             "10.0",
-            {"column_A": "", "column_B": "10.0"},
+            {"column_A": "", "column_B": "", "": "", "Total": "10.0"},
             id="check_results_with_more_than_one_data_element",
         ),
     ],
@@ -127,8 +127,8 @@ def test_print_nicely_the_data(data, total, result):
             "dim_company",
             [
                 call(
-                    columns=["untested columns", "% coverage"],
-                    data={"age": "40.0", "id": "", "name": ""},
+                    columns=["Untested Columns", "% coverage"],
+                    data={"age": "", "id": "", "name": "", "": "", "Total": "40.0"},
                     title="Test Coverage",
                 )
             ],
@@ -207,8 +207,8 @@ def test_get_project_test_coverage(mocker, dbt_tests, call_input):
             "dim_company",
             [
                 call(
-                    columns=["undocument columns", "% coverage"],
-                    data={"id": "", "name": "", "age": "", "address": "20.0"},
+                    columns=["Undocument Columns", "% coverage"],
+                    data={"id": "", "name": "", "age": "", "address": "", "": "", "Total": "20.0"},
                     title="Documentation Coverage",
                 )
             ],

--- a/tests/audit_task_test.py
+++ b/tests/audit_task_test.py
@@ -79,7 +79,7 @@ def test_get_project_total_test_coverage(dbt_definitions, result):
 )
 def test_calculate_coverage_percentage(failures, total, result):
     audit_task = __init_descriptions()
-    assert audit_task.calculate_coverage_percentage(number_failures=failures, total=total) == result
+    assert audit_task.calculate_coverage_percentage(misses=failures, total=total) == result
 
 
 @pytest.mark.parametrize(
@@ -163,7 +163,7 @@ def test_get_model_test_coverage(mocker, dbt_tests, model_name, call_input):
             [
                 call(
                     columns=["Model Name", "% coverage"],
-                    data={"dim_company": "40.0", "stg_customers": "100.0", "": "", "TOTAL": "50.0"},
+                    data={"dim_company": "40.0", "stg_customers": "100.0", "": "", "Total": "50.0"},
                     title="Test Coverage",
                 )
             ],


### PR DESCRIPTION
# Description
Improves the following visual aspects of the audit task reports:
- Table title is now actually printing as the title (needed to explicitly pass the `title=` kwarg
- The word "Total" is not first-letter captialised
- The total line is now printed separately on model report instead of appended to the last column

# How was the change tested
Interactively and some of the test assumptions were modified to reflect the changes.

# Issue Information
No issue

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
