### PR TITLE
fix: ensure all test outputs print

### DIFF
--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -85,8 +85,8 @@ class AuditTask(BaseTask):
 
         if not columns:
             logger.info(
-                f"There is not documentation for the model '{self.model_name}' "
-                "you might need to run `dbt-sugar doc` first."
+                f"There is no documentation entry for '{self.model_name}' in your schema.yml files. "
+                "You might need to run `dbt-sugar doc` first."
             )
             return
 

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -1,4 +1,5 @@
 """Document Task module."""
+import copy
 from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional, Tuple
@@ -209,7 +210,8 @@ class DocumentationTask(BaseTask):
             )
             for column in self.column_update_payload.keys():
                 tests = self.column_update_payload[column].get("tests", [])
-                for test in tests:
+                tests_ = copy.deepcopy(tests)
+                for test in tests_:
                     has_passed = self.connector.run_test(
                         test,
                         schema,


### PR DESCRIPTION
# Description
When a test failed and was removed from the list the progress priting was missing some of the tests. This is because we're doing removal based on index

This PR makes a copy of the list so that it is always available to printing and leaves the removal of tests into the original list thereby retaining the intended behaviour but allowing for log printing.

# How was the change tested
Interactively

# Issue Information
Resolves #156

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
