### PR TITLE
fix: ensure model name and description is first

### DIFF
--- a/changelog/167.fix.rst
+++ b/changelog/167.fix.rst
@@ -1,0 +1,1 @@
+When creating or modifying a model entry in schema.ymls we now ensure and guarantee that the model ``name`` and ``description`` keys are always first. Column names and descriptions are sorted alphabetically by column name however to make the ``schema.yml`` easier on th eyes.

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -110,7 +110,7 @@ class DocumentationTask(BaseTask):
         ordered_dict = OrderedDict(model)
         ordered_dict.move_to_end("description", last=False)
         ordered_dict.move_to_end("name", last=False)
-        return dict(ordered_dict)
+        return ordered_dict
 
     def order_schema_yml(self, content_yml: Dict[str, Any]):
         """

--- a/tests/test_dbt_project/jaffle_shop/models/marts/core/schema.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/marts/core/schema.yml
@@ -6,18 +6,18 @@ models:
       on a customer's orders
     columns:
       - name: customer_id
-        description: Identifier of a customer. PK of the dim_company model
+        description: PK
         tests:
           - unique
           - not_null
-      - name: first_name
-        description: Customer's first name. PII.
-      - name: last_name
-        description: Customer's last name. PII.
       - name: email
         description: Customer's email address. PII.
+      - name: first_name
+        description: Customer's first name. PII.
       - name: first_order
         description: Date (UTC) of a customer's first order
+      - name: last_name
+        description: Customer's last name. PII.
       - name: most_recent_order
         description: Date (UTC) of a customer's most recent order
       - name: number_of_orders

--- a/tests/test_dbt_project/jaffle_shop/models/staging/schema.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/staging/schema.yml
@@ -6,7 +6,7 @@ models:
         tests:
           - unique
           - not_null
-        description: Unique identifier of the customer who made the purchase. Links to the dim_customer table.
+        description: PK
   - name: stg_orders
     columns:
       - name: order_id


### PR DESCRIPTION
# Description

In #159 we implemented `OrderedDict` to ensure that we could explicitly control the order of the `name` and `description` keys but somehow we were destroying all that hard work by casting it to a regular `dict()` at return time.

This PR removes the cast and the schema yaml is in good order now.

# How was the change tested

# Issue Information
Resolves #165

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
