### PR TITLE
fix: exclude dbt_modules from search path

### DIFF
--- a/changelog/187.fix.rst
+++ b/changelog/187.fix.rst
@@ -1,0 +1,1 @@
+The folder ``dbt_modules`` is now excluded from dbt-sugar's search path

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -9,7 +9,7 @@ from dbt_sugar.core.clients.yaml_helpers import open_yaml, save_yaml
 
 COLUMN_NOT_DOCUMENTED = "No description for this column."
 MODEL_NOT_DOCUMENTED = "No description for this model."
-EXCLUDE_TARGET_FILES_PATTERN = r"\/target\/"
+EXCLUDE_TARGET_FILES_PATTERN = r"\/target\/|\/dbt_modules\/"
 
 
 class BaseTask(abc.ABC):

--- a/tests/test_dbt_project/jaffle_shop/packages.yml
+++ b/tests/test_dbt_project/jaffle_shop/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: fishtown-analytics/dbt_utils
+    version: 0.6.4


### PR DESCRIPTION
# Description
dbt packages get installed inside of `dbt_modules` when running `dbt deps`. 

we now exclude it from the search path as dbt-sugar should never attempt to document or audit those folders.

# Issue Information
Resolves #183
(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
