### PR TITLE
fix: use excluded_tables info to skip excluded models

### DIFF
--- a/changelog/189.fix.rst
+++ b/changelog/189.fix.rst
@@ -1,4 +1,6 @@
-dbt-sugar now uses the user-provided list to exlude any number of tables from its scope.
-  - If a user asks to document a model that is part of the exclude list the app will waise a ``ValueError`` and tell users why
-  - Any model excluded from dbt-sugar's scope will also not be included in any of the ``dbt-sugar audit`` coverage statistics.
-  🚧 **BREAKING-CHANGE**: ``excluded_tables`` has been renamed to ``excluded_models`` to be consisten with dbt terminology. Users are advised to update their ``sugar_config.yml`` if they already used the ``excluded_tables`` config variable.
+dbt-sugar now uses the user-provided list to exclude any number of tables from its scope.
+
+- If a user asks to document a model that is part of the exclude list the app will raise a ``ValueError`` and tell users why
+- Any model excluded from dbt-sugar's scope will also not be included in any of the ``dbt-sugar audit`` coverage statistics.
+
+🚧 **BREAKING-CHANGE**: ``excluded_tables`` has been renamed to ``excluded_models`` to be consistent with dbt terminology. Users are advised to update their ``sugar_config.yml`` if they already used the ``excluded_tables`` config variable.

--- a/changelog/189.fix.rst
+++ b/changelog/189.fix.rst
@@ -1,0 +1,4 @@
+dbt-sugar now uses the user-provided list to exlude any number of tables from its scope.
+  - If a user asks to document a model that is part of the exclude list the app will waise a ``ValueError`` and tell users why
+  - Any model excluded from dbt-sugar's scope will also not be included in any of the ``dbt-sugar audit`` coverage statistics.
+  🚧 **BREAKING-CHANGE**: ``excluded_tables`` has been renamed to ``excluded_models`` to be consisten with dbt terminology. Users are advised to update their ``sugar_config.yml`` if they already used the ``excluded_tables`` config variable.

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -21,8 +21,8 @@ class DbtProjectsModel(BaseModel):
 
     name: str
     path: str
-    excluded_folders: Optional[Union[List[str], str]]
-    excluded_tables: Optional[Union[List[str], str]]
+    excluded_folders: Optional[Union[List[str], str]] = []
+    excluded_tables: Optional[Union[List[str], str]] = []
 
 
 class SyrupModel(BaseModel):

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -22,7 +22,7 @@ class DbtProjectsModel(BaseModel):
     name: str
     path: str
     excluded_folders: Optional[Union[List[str], str]] = []
-    excluded_tables: Optional[Union[List[str], str]] = []
+    excluded_models: Optional[Union[List[str], str]] = []
 
 
 class SyrupModel(BaseModel):

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -224,13 +224,13 @@ class BaseTask(abc.ABC):
         self.dbt_definitions[column_name] = column_description
 
     def remove_excluded_models(self, content: Dict[str, Any]):
-        """Removes models that are excluded_tables from the models dict"""
+        """Removes models that are excluded_models from the models dict"""
         models = content.get("models", [])
-        if self._sugar_config.dbt_project_info.get("excluded_tables"):
+        if self._sugar_config.dbt_project_info.get("excluded_models"):
             filtered_models = [
                 model_dict
                 for model_dict in models
-                if not model_dict["name"] in self._sugar_config.dbt_project_info["excluded_tables"]
+                if not model_dict["name"] in self._sugar_config.dbt_project_info["excluded_models"]
             ]
 
             return filtered_models

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -56,6 +56,13 @@ class DocumentationTask(BaseTask):
             )
 
         self.connector = connector(dbt_credentials)
+        print(self._sugar_config.dbt_project_info)
+        if model in self._sugar_config.dbt_project_info.get("excluded_tables", []):
+            logger.warning(
+                f"You decided to exclude '{model}' from dbt-sugar's scope. "
+                "If you want to document it you will need to remove it from the excluded_tables list"
+            )
+            return 1
         columns_sql = self.connector.get_columns_from_table(model, schema)
         if columns_sql:
             return self.orchestrate_model_documentation(schema, model, columns_sql)

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -56,13 +56,13 @@ class DocumentationTask(BaseTask):
             )
 
         self.connector = connector(dbt_credentials)
-        print(self._sugar_config.dbt_project_info)
-        if model in self._sugar_config.dbt_project_info.get("excluded_tables", []):
-            logger.warning(
+
+        # exit early if model is in the excluded_models list
+        if model in self._sugar_config.dbt_project_info.get("excluded_models", []):
+            raise ValueError(
                 f"You decided to exclude '{model}' from dbt-sugar's scope. "
-                "If you want to document it you will need to remove it from the excluded_tables list"
+                "If you want to document it you will need to remove it from the excluded_models list"
             )
-            return 1
         columns_sql = self.connector.get_columns_from_table(model, schema)
         if columns_sql:
             return self.orchestrate_model_documentation(schema, model, columns_sql)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -54,7 +54,7 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
             {
                 "name": "dbt_sugar_test",
                 "path": "./tests/test_dbt_project/dbt_sugar_test",
-                "excluded_tables": ["table_a"],
+                "excluded_models": ["table_a"],
                 "excluded_folders": ["folder_to_exclude"],
             },
         ],
@@ -124,7 +124,7 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                     }
                 ],
             },
@@ -138,12 +138,12 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                     },
                     {
                         "name": "dbt_sugar_test_2",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                     },
                 ],
             },
@@ -187,7 +187,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],
@@ -204,7 +204,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],
@@ -221,7 +221,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_tables": ["table_a"],
+                        "excluded_models": ["table_a"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -8,7 +8,7 @@ syrups:
         path: "./tests/test_dbt_project/dbt_sugar_test"
         excluded_folders:
           - folder_to_exclude
-        excluded_tables:
+        excluded_models:
           - table_a
   - name: syrup_2
     dbt_projects:
@@ -22,7 +22,7 @@ syrups:
     dbt_projects:
       - name: jaffle_shop
         path: "./test_dbt_project/jaffle_shop"
-        #excluded_tables:
+        #excluded_models:
         #- orders
   # TODO: Remove this when we have dealt with this regression.
   # ! REGRESSION
@@ -30,7 +30,7 @@ syrups:
   # dbt_projects:
   # - name: dwh
   # path: path
-  # excluded_tables:
+  # excluded_models:
   # - table_a
   # - name: prediction
   # path: path

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -22,6 +22,8 @@ syrups:
     dbt_projects:
       - name: jaffle_shop
         path: "./test_dbt_project/jaffle_shop"
+        #excluded_tables:
+        #- orders
   # TODO: Remove this when we have dealt with this regression.
   # ! REGRESSION
   # - name: syrup_3

--- a/tests/sugar_config_missing_default.yml
+++ b/tests/sugar_config_missing_default.yml
@@ -5,13 +5,13 @@ syrups:
     dbt_projects:
       - name: dwh
         path: path
-        excluded_tables:
+        excluded_models:
           - table_a
   - name: syrup_2
     dbt_projects:
       - name: dwh
         path: path
-        excluded_tables:
+        excluded_models:
           - table_a
       - name: prediction
         path: path


### PR DESCRIPTION

# Description

- implement model exclusion working for the audit task
- make app exit early when user tries to document an excluded table

# How was the change tested
- [x] add a test scenario 

# Issue Information
Resolves #185

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
