### PR TITLE
feat: allow for arbitrarily named model property files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: black
         language_version: python3
-        args: [--line-length=100, --target-version=py37]
+        args: [--line-length=100, --target-version=py38]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
@@ -43,4 +43,5 @@ repos:
       - id: flake8
         exclude: ^tests/
         additional_dependencies: [flake8-docstrings]
-        args: ["--max-line-length=120", "--ignore=D102,D104,D401,D400,D107"]
+        args:
+          ["--max-line-length=120", "--ignore=D102,D104,D401,D400,D107,W503"]

--- a/changelog/193.feat.rst
+++ b/changelog/193.feat.rst
@@ -1,0 +1,1 @@
+dbt sugar now supports arbitrarily named model property files (schema.yml). This means just like in `dbt core <https://docs.getdbt.com/reference/model-properties>`_ , users can name their model property files any way they like.

--- a/dbt_sugar/core/config/config.py
+++ b/dbt_sugar/core/config/config.py
@@ -80,7 +80,6 @@ class DbtSugarConfig:
     @property
     def config(self):
         if self.config_model:
-            logger.debug(f"Config model dict: {self.config_model.dict()}")
             config_dict = self._integrate_cli_flags(self.config_model.dict())
             return config_dict
         raise AttributeError(f"{type(self).__name__} does not have a parsed config.")
@@ -199,3 +198,4 @@ class DbtSugarConfig:
         self.retain_syrup()
         self.assert_only_one_dbt_project_in_scope()
         _ = self.assert_dbt_projects_exist()
+        logger.debug(f"Config model dict: {self.config_model.dict()}")

--- a/dbt_sugar/core/task/audit.py
+++ b/dbt_sugar/core/task/audit.py
@@ -43,7 +43,6 @@ class AuditTask(BaseTask):
                 logger.info("The model is not documented.")
                 return 1
             self.model_content = open_yaml(path_file)
-            logger.debug(f"Content for '{self.model_name}' - audit_task: {self.model_content} ")
             self.derive_model_coverage()
         else:
             logger.info(f"Running audit of dbt project in {self.dbt_path}.\n")

--- a/tests/audit_task_test.py
+++ b/tests/audit_task_test.py
@@ -209,7 +209,7 @@ def test_get_project_test_coverage(mocker, dbt_tests, call_input):
             "dim_company",
             [
                 call(
-                    columns=["Undocument Columns", "% coverage"],
+                    columns=["Undocumented Columns", "% coverage"],
                     data={"id": "", "name": "", "age": "", "address": "", "": "", "Total": "20.0"},
                     title="Documentation Coverage",
                 )

--- a/tests/base_task_test.py
+++ b/tests/base_task_test.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+from unittest.mock import call
+
+import pytest
+
+from dbt_sugar.core.config.config import DbtSugarConfig
+from dbt_sugar.core.flags import FlagParser
+from dbt_sugar.core.main import parser
+from dbt_sugar.core.task.audit import AuditTask
+from dbt_sugar.core.task.base import COLUMN_NOT_DOCUMENTED
+
+FIXTURE_DIR = Path(__file__).resolve().parent
+
+
+def __init_descriptions():
+    flag_parser = FlagParser(parser)
+    config_filepath = Path(FIXTURE_DIR).joinpath("sugar_config.yml")
+    flag_parser.consume_cli_arguments(
+        test_cli_args=["audit", "--config-path", str(config_filepath)]
+    )
+    sugar_config = DbtSugarConfig(flag_parser)
+    sugar_config.load_config()
+    audit_task = AuditTask(flag_parser, FIXTURE_DIR, sugar_config=sugar_config)
+    audit_task.dbt_definitions = {"columnA": "descriptionA", "columnB": "descriptionB"}
+    audit_task.repository_path = Path("tests/test_dbt_project/").resolve()
+    return audit_task
+
+
+@pytest.mark.parametrize(
+    "model_name, is_exluded_model",
+    [
+        pytest.param("my_first_dbt_model", False, id="model is not excluded"),
+        pytest.param("my_first_dbt_model_excluded", True, id="model is not excluded"),
+    ],
+)
+def test_is_excluded_model(model_name, is_exluded_model):
+    audit_task = __init_descriptions()
+    if is_exluded_model:
+        with pytest.raises(ValueError):
+            audit_task.is_exluded_model(model_name)
+    else:
+        audit_task.is_exluded_model(model_name)

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -54,7 +54,7 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
             {
                 "name": "dbt_sugar_test",
                 "path": "./tests/test_dbt_project/dbt_sugar_test",
-                "excluded_models": ["table_a"],
+                "excluded_models": ["my_first_dbt_model_excluded"],
                 "excluded_folders": ["folder_to_exclude"],
             },
         ],
@@ -124,7 +124,7 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                     }
                 ],
             },
@@ -138,12 +138,12 @@ def test_load_config(datafiles, has_no_default_syrup, is_missing_syrup, is_missi
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                     },
                     {
                         "name": "dbt_sugar_test_2",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                     },
                 ],
             },
@@ -187,7 +187,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],
@@ -204,7 +204,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],
@@ -221,7 +221,7 @@ def test_assert_only_one_dbt_project_in_scope(
                     {
                         "name": "dbt_sugar_test",
                         "path": "./tests/test_dbt_project/dbt_sugar_test",
-                        "excluded_models": ["table_a"],
+                        "excluded_models": ["my_first_dbt_model_excluded"],
                         "excluded_folders": ["folder_to_exclude"],
                     }
                 ],

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -650,7 +650,7 @@ def test_get_not_documented_columns(content, model_name, result):
         ),
     ],
 )
-def test_change_model_description(mocker, content, model_name, is_already_documented, result):
+def test_update_model_description(mocker, content, model_name, is_already_documented, result):
     doc_task = __init_descriptions()
     mocker.patch(
         "questionary.prompt",
@@ -659,7 +659,7 @@ def test_change_model_description(mocker, content, model_name, is_already_docume
             "model_description": "New description for the model.",
         },
     )
-    assert doc_task.change_model_description(content, model_name, is_already_documented) == result
+    assert doc_task.update_model_description(content, model_name, is_already_documented) == result
 
 
 def test_document_columns(mocker):
@@ -699,11 +699,19 @@ def test_document_columns(mocker):
             id="find_model",
         ),
         pytest.param("model_does_not_exists", None, False, id="find_model_does_not_exists"),
+        pytest.param(
+            "my_second_dbt_model",
+            Path(
+                "tests/test_dbt_project/dbt_sugar_test/models/example/arbitrary_name.yml"
+            ).resolve(),
+            True,
+            id="find_model",
+        ),
     ],
 )
-def test_find_model_in_dbt(model_name, path_model, schema_exists):
+def test_find_model_schema_file(model_name, path_model, schema_exists):
     doc_task = __init_descriptions()
-    path_file, schema = doc_task.find_model_in_dbt(model_name)
+    path_file, schema = doc_task.find_model_schema_file(model_name)
     assert path_file == path_model
     assert schema == schema_exists
 

--- a/tests/doc_task_test.py
+++ b/tests/doc_task_test.py
@@ -172,9 +172,9 @@ def test_update_model_description_test_tags(mocker, content, model_name, ui_resp
         ),
     ],
 )
-def test_save_descriptions_from_schema(content, column, description):
+def test_load_descriptions_from_a_schema_file(content, column, description):
     doc_task = __init_descriptions()
-    doc_task.save_descriptions_from_schema(content, "")
+    doc_task.load_descriptions_from_a_schema_file(content, "")
     assert doc_task.dbt_definitions[column] == description
 
 

--- a/tests/sugar_config.yml
+++ b/tests/sugar_config.yml
@@ -9,7 +9,7 @@ syrups:
         excluded_folders:
           - folder_to_exclude
         excluded_models:
-          - table_a
+          - my_first_dbt_model_excluded
   - name: syrup_2
     dbt_projects:
       - name: dwh

--- a/tests/test_dbt_project/dbt_sugar_test/models/example/arbitrary_name.yml
+++ b/tests/test_dbt_project/dbt_sugar_test/models/example/arbitrary_name.yml
@@ -1,0 +1,5 @@
+version: 2
+
+models:
+  - name: my_second_dbt_model
+    description: dummy description for my second dbt model

--- a/tests/test_dbt_project/dbt_sugar_test/models/example/my_first_dbt_model_excluded.sql
+++ b/tests/test_dbt_project/dbt_sugar_test/models/example/my_first_dbt_model_excluded.sql
@@ -1,0 +1,28 @@
+
+/*
+    Welcome to your first dbt model!
+    Did you know that you can also configure models directly within SQL files?
+    This will override configurations stated in dbt_project.yml
+
+    Try changing "table" to "view" below
+*/
+
+{{ config(materialized='table') }}
+
+with source_data as (
+
+    select
+        1 as id
+        , 42 as answer
+        , 'what is the meaning of life?' as question
+
+)
+
+select *
+from source_data
+
+/*
+    Uncomment the line below to remove records with null `id` values
+*/
+
+-- where id is not null

--- a/tests/test_dbt_project/jaffle_shop/models/schema.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/schema.yml
@@ -1,61 +1,26 @@
 version: 2
-
 models:
   - name: customers
-    description: This table has basic information about a customer, as well as some derived facts based on a customer's orders
-
+    description:
+      This table has basic information about a customer, as well as some derived facts based
+      on a customer's orders
     columns:
       - name: customer_id
         description: This is a unique identifier for a customer
         tests:
           - unique
           - not_null
-
-      - name: first_name
-        description: Customer's first name. PII.
-
-      - name: last_name
-        description: Customer's last name. PII.
-
       - name: email
         description: Customer's email address. PII.
-
+      - name: first_name
+        description: Customer's first name. PII.
       - name: first_order
         description: Date (UTC) of a customer's first order
-
+      - name: last_name
+        description: Customer's last name. PII.
       - name: most_recent_order
         description: Date (UTC) of a customer's most recent order
-
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
-
       - name: total_order_amount
         description: Total value (AUD) of a customer's orders
-
-  - name: orders
-    description: This table has basic information about orders, as well as some derived facts based on payments
-
-    columns:
-      - name: order_id
-        tests:
-          - unique
-          - not_null
-        description: This is a unique identifier for an order
-
-      - name: customer_id
-        description: Foreign key to the customers table
-        tests:
-          - not_null
-          - relationships:
-              to: ref('customers')
-              field: customer_id
-
-      - name: order_date
-        description: Date (UTC) that the order was placed
-
-      - name: status
-        description: '{{ doc("orders_status") }}'
-        tests:
-          - accepted_values:
-              values:
-                ["placed", "shipped", "completed", "return_pending", "returned"]

--- a/tests/test_dbt_project/jaffle_shop/models/some_other.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/some_other.yml
@@ -1,0 +1,30 @@
+version: 2
+
+models:
+  - name: orders
+    description: This table has basic information about orders, as well as some derived facts based on payments
+
+    columns:
+      - name: order_id
+        tests:
+          - unique
+          - not_null
+        description: This is a unique identifier for an order
+
+      - name: customer_id
+        description: Foreign key to the customers table
+        tests:
+          - not_null
+          - relationships:
+              to: ref('customers')
+              field: customer_id
+
+      - name: order_date
+        description: Date (UTC) that the order was placed
+
+      - name: status
+        description: '{{ doc("orders_status") }}'
+        tests:
+          - accepted_values:
+              values:
+                ["placed", "shipped", "completed", "return_pending", "returned"]


### PR DESCRIPTION

# Description

- rename confusing global dict building functions
- remove orders from schema.yml
- add orders in another schema file with arbitrary name
- rework logic to find models in schema files to work with arbitrary names

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information
Resolves #184

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
