### PR TITLE
fix: use `.get()` when looking for model content in yml files

### DIFF
--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -131,7 +131,7 @@ class BaseTask(abc.ABC):
             the description, tags and tests to update.
         """
         content = open_yaml(path_file)
-        for model in content["models"]:
+        for model in content.get("models", []):
             if model["name"] == model_name:
                 for column in model.get("columns", []):
                     column_name = column["name"]
@@ -169,7 +169,7 @@ class BaseTask(abc.ABC):
             the description to update.
         """
         content = open_yaml(path_file)
-        for model in content["models"]:
+        for model in content.get("models", []):
             for column in model.get("columns", []):
                 column_name = column["name"]
                 if column_name in dict_column_description_to_update.keys():


### PR DESCRIPTION
# Description
While I was testing dbt-sugar was trying to read a schema.yml without models attribute and it was failing, so getting the models attribute with get.

# How was the change tested
Ran it in local.

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
