### PR TITLE
fix: add warehouse parameter to snowflake URL creator

### DIFF
--- a/changelog/205.fix.rst
+++ b/changelog/205.fix.rst
@@ -1,0 +1,1 @@
+The snowflake_connector now passes the expected `warehouse` parameter when creating a connection. This fixes an issue reported by `@sphinks <https://github.com/sphinks>`_.

--- a/dbt_sugar/core/connectors/snowflake_connector.py
+++ b/dbt_sugar/core/connectors/snowflake_connector.py
@@ -35,5 +35,6 @@ class SnowflakeConnector(BaseConnector):
             password=connection_params.get("password", str()),
             database=connection_params.get("database", str()),
             account=connection_params.get("account", str()),
+            warehouse=connection_params.get("warehouse", str()),
         )
         self.engine = sqlalchemy.create_engine(self.connection_url)


### PR DESCRIPTION
# Description
Looks like we forgot to pass the `warehouse` to the snowflake URL connector. We do now!

# How was the change tested
I cannot test against a snowflake warehouse sadly so hopefully someone will be able to help. Gonna see with @sphinks (the person who reported the bug if he can help)

# Issue Information
Resolves #204

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
