### PR TITLE
feat: collect user complex input via text editor

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party =luddite,packaging,pretty_errors,pydantic,pyfiglet,pytest,questionary,rich,snowflake,sqlalchemy,yaml,yamlloader
+known_third_party =click,luddite,packaging,pretty_errors,pydantic,pyfiglet,pytest,questionary,rich,snowflake,sqlalchemy,yaml,yamlloader

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -5,6 +5,8 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+import yaml
+
 from dbt_sugar.core.clients.yaml_helpers import open_yaml, save_yaml
 from dbt_sugar.core.config.config import DbtSugarConfig
 from dbt_sugar.core.flags import FlagParser
@@ -146,6 +148,7 @@ class BaseTask(abc.ABC):
                         # Update the tests without duplicating them.
                         tests = dict_column_description_to_update[column_name].get("tests")
                         if tests:
+                            tests = yaml.safe_load(tests)
                             column["tests"] = self.__combine_two_list_without_duplicates(
                                 column.get("tests", []), tests
                             )

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -149,6 +149,8 @@ class BaseTask(abc.ABC):
                         tests = dict_column_description_to_update[column_name].get("tests")
                         if tests:
                             tests = yaml.safe_load(tests)
+                            if not isinstance(tests, list):
+                                tests = [tests]
                             column["tests"] = self.__combine_two_list_without_duplicates(
                                 column.get("tests", []), tests
                             )

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -193,10 +193,11 @@ class DocumentationTask(BaseTask):
         except KeyboardInterrupt:
             logger.info("The user has exited the doc task, all changes have been discarded.")
             return 0
-        print(f"content about to be saved {content}")
-        print(f"column_update_payload: {self.column_update_payload}")
         save_yaml(schema_file_path, self.order_schema_yml(content))
-        self.check_tests(schema, model_name)
+
+        # TODO: Hook it up into the new check_tests function which uses subprocess
+        # self.check_tests(schema, model_name)
+
         self.update_model_description_test_tags(
             schema_file_path, model_name, self.column_update_payload
         )

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -242,11 +242,17 @@ class UserInputCollector:
                     message="Would you like to add any tests?"
                 ).unsafe_ask()
                 if wants_to_add_tests:
-                    tests = self.collect_rich_user_input()
-                    # tests = questionary.checkbox(
-                    # message="Please select one or more tests from the list below",
-                    # choices=AVAILABLE_TESTS,
-                    # ).unsafe_ask()
+                    wants_to_pop_editor = questionary.confirm(
+                        message="Do you want to add a complex or custom tests? If, so we'll open a test editor for "
+                        f"you, otherwise you can choose from the following builtins: {AVAILABLE_TESTS}"
+                    ).unsafe_ask()
+                    if wants_to_pop_editor:
+                        tests = self.collect_rich_user_input()
+                    else:
+                        tests = questionary.checkbox(
+                            message="Please select one or more tests from the list below",
+                            choices=AVAILABLE_TESTS,
+                        ).unsafe_ask()
                     if tests:
                         results[column]["tests"] = tests
 

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -190,6 +190,11 @@ class UserInputCollector:
         self._is_valid_question_payload = True
 
     def collect_rich_user_input(self) -> str:
+        """Uses click to open up a text editor to collect rich user input.
+
+        Returns:
+            str: string version of the text input which will then be loaded.
+        """
         tests = click.edit(extension=".yml")
         tests = tests.replace("\t", "  ")
         return tests

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -3,6 +3,7 @@
 import copy
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Union, cast
 
+import click
 import questionary
 from pydantic import BaseModel, validator
 
@@ -188,6 +189,11 @@ class UserInputCollector:
 
         self._is_valid_question_payload = True
 
+    def collect_rich_user_input(self) -> str:
+        tests = click.edit(extension=".yml")
+        tests = tests.replace("\t", "  ")
+        return tests
+
     def _iterate_through_columns(
         self, cols: List[str]
     ) -> Mapping[str, Mapping[str, Union[str, List[str]]]]:
@@ -236,10 +242,11 @@ class UserInputCollector:
                     message="Would you like to add any tests?"
                 ).unsafe_ask()
                 if wants_to_add_tests:
-                    tests = questionary.checkbox(
-                        message="Please select one or more tests from the list below",
-                        choices=AVAILABLE_TESTS,
-                    ).unsafe_ask()
+                    tests = self.collect_rich_user_input()
+                    # tests = questionary.checkbox(
+                    # message="Please select one or more tests from the list below",
+                    # choices=AVAILABLE_TESTS,
+                    # ).unsafe_ask()
                     if tests:
                         results[column]["tests"] = tests
 

--- a/tests/test_dbt_project/jaffle_shop/models/schema.yml
+++ b/tests/test_dbt_project/jaffle_shop/models/schema.yml
@@ -46,3 +46,11 @@ models:
           - PK
       - name: status
         description: Status the order is in.
+        tests:
+          - list_of_vals:
+              - a
+              - b
+          - accepted_values:
+              - a
+              - b
+          - unique


### PR DESCRIPTION
# Description
In order to add all sorts of tests (especially complex ones with arguments) we should allow the user to write tests in the form of a yaml (just as if they were manually writing those tests in model descriptors yml files).

To do so, we're using `click.edit()` which brings up the system configured text editor.

**Still to do**:
- [ ] integrate into the subprocess branch after it's been rebased.
- [ ] look into how users can choose which editor to use and make sure it's documented. We don't want users to end up having to use vim or any other editor they are not comfortable using. In theory we should even look into whether a visual editor can be set up in the users evironments.
- [ ] test out the flow once we've integrated it and make sure we have clear ways of signalling if the user made a yaml syntax issue, which, in theory, should make `dbt` throw a syntax error on compile. We'll need to make sure that the subprocess method is able to capture and escape those properly.

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information

(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
