### PR TITLE
fix: rename and rephrase news fragment

### DIFF
--- a/changelog/194.feature_primary_key_tests.md
+++ b/changelog/194.feature_primary_key_tests.md
@@ -1,1 +1,0 @@
-Adds functionality of adding automatically the unique and nut_null tests into the primary key column (getting it from the configuration part in the SQL file).

--- a/changelog/203.feature.md
+++ b/changelog/203.feature.md
@@ -1,0 +1,1 @@
+dbt-sugar will now automatically add a `unique` and `not_null` test to the column listed as `primary_key` in your model's `{{ config() }}` block.


### PR DESCRIPTION
# Description

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information

(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [ ] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
