### PR TITLE
refactor: add use_describe to base

### DIFF
--- a/dbt_sugar/core/connectors/base.py
+++ b/dbt_sugar/core/connectors/base.py
@@ -30,9 +30,7 @@ class BaseConnector(ABC):
         self.engine = sqlalchemy.create_engine(**connection_params)
 
     def get_columns_from_table(
-        self,
-        target_table: str,
-        target_schema: str,
+        self, target_table: str, target_schema: str, use_describe: bool = False
     ) -> Optional[List[Tuple[Any]]]:
         """
         Method that creates cursor to run a query.

--- a/dbt_sugar/core/connectors/base.py
+++ b/dbt_sugar/core/connectors/base.py
@@ -44,8 +44,7 @@ class BaseConnector(ABC):
         """
         inspector = sqlalchemy.engine.reflection.Inspector.from_engine(self.engine)
         columns = inspector.get_columns(target_table, target_schema)
-        columns_names = [column["name"] for column in columns]
-        return columns_names
+        return [column["name"] for column in columns]
 
     def run_test(self, test_name: str, schema: str, table: str, column: str) -> bool:
         """
@@ -68,8 +67,7 @@ class BaseConnector(ABC):
             "not_null": f"select count(*) as errors from {schema}.{table} where {column} is null",
         }
         query = TESTS[test_name]
-        result = self.execute_and_check(query)
-        return result
+        return self.execute_and_check(query)
 
     def execute_and_check(self, query) -> bool:
         """


### PR DESCRIPTION
- feat: add describe table logic in snowflake connector (#212)
- feat: automatic insertion of primary key tests (#203)
- add `use_describe` to the base `get_columns_from_table` def

# Description
Because we allow the `snowflake_connector.get_columns_from_table()` to take a `use_describe` we also add this parameter to the base so that the signatures are the same a less persmissive than if we allowed `**kwargs`.

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

