### PR TITLE
feat: collect rich user input for tests with subprocess

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party =luddite,packaging,pretty_errors,pydantic,pyfiglet,pytest,questionary,rich,snowflake,sqlalchemy,yaml,yamlloader
+known_third_party =click,luddite,packaging,pretty_errors,pydantic,pyfiglet,pytest,questionary,rich,snowflake,sqlalchemy,yaml,yamlloader

--- a/changelog/238.feature.md
+++ b/changelog/238.feature.md
@@ -1,0 +1,1 @@
+dbt-sugar can now add your custom tests via the console, you only need to write the test as you want to look in the schema.yml. dbt-sugar will check if the test PASSES and if it does will add the custom test to your schema.yml.

--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -1,12 +1,12 @@
 """Document Task module."""
-import copy
 import re
+import subprocess
 from collections import OrderedDict
 from pathlib import Path
+from shlex import quote
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
 from rich.console import Console
-from rich.progress import BarColumn, Progress
 
 from dbt_sugar.core.clients.dbt import DbtProfile
 from dbt_sugar.core.clients.yaml_helpers import open_yaml, save_yaml
@@ -52,7 +52,6 @@ class DocumentationTask(BaseTask):
         model = self._flags.model
         schema = self._dbt_profile.profile.get("target_schema", "")
 
-        connector = self.get_connector()
         dbt_credentials = self._dbt_profile.profile
         connector = DB_CONNECTORS.get(dbt_credentials.get("type", ""))
         if not connector:
@@ -118,8 +117,7 @@ class DocumentationTask(BaseTask):
         """
         # DEPRECATION: Drop ordered dict when dropping python 3.6 support
         ordered_dict = OrderedDict(model)
-        if ordered_dict.get("description"):
-            ordered_dict.move_to_end("description", last=False)
+        ordered_dict.move_to_end("description", last=False)
         ordered_dict.move_to_end("name", last=False)
         return ordered_dict
 
@@ -258,51 +256,81 @@ class DocumentationTask(BaseTask):
         except KeyboardInterrupt:
             logger.info("The user has exited the doc task, all changes have been discarded.")
             return 0
+
         save_yaml(schema_file_path, self.order_schema_yml(content))
         self.add_primary_key_tests(schema_content=content, model_name=model_name)
-        self.check_tests(schema, model_name)
+
         self.update_model_description_test_tags(
             schema_file_path, model_name, self.column_update_payload
         )
+        self.check_tests(schema_file_path, model_name)
         # Method to update the descriptions in all the schemas.yml
         self.update_column_descriptions(self.column_update_payload)
 
         return 0
 
-    def check_tests(self, schema: str, model_name: str) -> None:
+    def delete_failed_tests_from_schema(
+        self, path_file: Path, model_name: str, tests_to_delete: Dict[str, List[str]]
+    ):
+        """
+        Method to delete the failing tests from the schema.yml.
+
+        Args:
+            path_file (Path): Path of the schema.yml file to update.
+            model_name (str): Name of the model to document.
+            tests_to_delete (Dict[str, List[str]]): with the tests that have failed.
+        """
+        content = open_yaml(path_file)
+        for model in content["models"]:
+            if model["name"] == model_name:
+                for column in model.get("columns", []):
+                    tests_to_delete_from_column = tests_to_delete.get(column["name"], [])
+                    tests_from_column = column.get("tests", [])
+                    tests_pass = [
+                        x for x in tests_from_column if x not in tests_to_delete_from_column
+                    ]
+                    if not tests_pass and tests_from_column:
+                        del column["tests"]
+                    elif tests_pass:
+                        column["tests"] = tests_pass
+        save_yaml(path_file, content)
+
+    def check_tests(self, path_file: Path, model_name: str) -> None:
         """
         Method to run and add test into a schema.yml, this method will:
 
         Run the tests and if they have been successful it will add them into the schema.yml.
 
         Args:
-            schema (str): Name of the schema where the model lives.
+            path_file (Path): Path of the schema.yml file to update.
             model_name (str): Name of the model to document.
         """
-        with Progress(
-            "[progress.description]{task.description}",
-            BarColumn(),
-            "[progress.percentage]{task.percentage:>3.0f}%",
-            transient=True,
-        ) as progress:
-            test_checking_task = progress.add_task(
-                "[bold] checking your tests...", total=len(self.column_update_payload.keys())
+        dbt_command = f"dbt test --models {quote(model_name)}".split()
+        dbt_result_command = subprocess.run(dbt_command, capture_output=True, text=True).stdout
+        tests_to_delete: Dict[str, List[str]] = {}
+
+        if "Compilation Error" in dbt_result_command:
+            logger.info(
+                "There's have been a compilation error in one or more custom tests that you have added.\n"
+                "Not able to check if the tests that you have added has PASS.\n"
+                f"The dbt original logs: {dbt_result_command}"
             )
-            for column in self.column_update_payload.keys():
-                tests = self.column_update_payload[column].get("tests", [])
-                tests_ = copy.deepcopy(tests)
-                for test in tests_:
-                    has_passed = self.connector.run_test(
-                        test,
-                        schema,
-                        model_name,
-                        column,
+
+        for column in self.column_update_payload.keys():
+            tests = self.column_update_payload[column].get("tests", [])
+            for test in tests:
+                test_name = test if type(test) == str else list(test.keys())[0]
+                test_passed_pattern = f"PASS {test_name}_{model_name}_{column}"
+                if re.search(test_passed_pattern, dbt_result_command):
+                    logger.info(f"The test {test} in the column {column} has PASSED.")
+                else:
+                    logger.info(
+                        f"The test {test} in the column {column} has FAILED to execute."
+                        "The test won't be added to your schema.yml file"
                     )
-                    message = self._generate_test_success_message(test, column, has_passed)
-                    progress.console.log(message)
-                    if not has_passed:
-                        tests.remove(test)
-                progress.advance(test_checking_task)
+                    tests_to_delete[column] = tests_to_delete.get(column, []) + [test]
+        if tests_to_delete:
+            self.delete_failed_tests_from_schema(path_file, model_name, tests_to_delete)
 
     @staticmethod
     def _generate_test_success_message(test_name: str, column_name: str, has_passed: bool):
@@ -396,12 +424,10 @@ class DocumentationTask(BaseTask):
 
                     columns = model.get("columns", [])
                     columns_names = [column["name"] for column in columns]
-
                     if column not in columns_names:
                         description = self.get_column_description_from_dbt_definitions(column)
                         logger.info(f"Updating column '{column.lower()}'")
                         columns.append({"name": column, "description": description})
-
         return content
 
     def create_new_model(

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -212,12 +212,12 @@ def test__document_already_documented_cols(
             {
                 "column_a": {
                     "description": "Dummy description",
-                    "tests": ["unique"],
+                    "tests": [{"accepted_values": ["a"]}],
                     "tags": ["Dummy description"],
                 },
                 "column_b": {
                     "description": "Dummy description",
-                    "tests": ["unique"],
+                    "tests": [{"accepted_values": ["a"]}],
                     "tags": ["Dummy description"],
                 },
             },
@@ -229,6 +229,7 @@ def test__iterate_through_columns(mocker, question_payload, expected_results):
     mocker.patch("questionary.text", return_value=Question("Dummy description"))
     mocker.patch("questionary.checkbox", return_value=Question(["unique"]))
     mocker.patch("questionary.confirm", return_value=Question(question_payload["ask_for_tests"]))
+    mocker.patch("click.edit", return_value="- accepted_values:\n\t- a")
     results = UserInputCollector(
         "undocumented_columns", question_payload=[], ask_for_tests=question_payload["ask_for_tests"]
     )._iterate_through_columns(cols=question_payload["col_list"])

--- a/tests/test_dbt_project/dbt_sugar_test/models/folder_to_exclude/schema.yml
+++ b/tests/test_dbt_project/dbt_sugar_test/models/folder_to_exclude/schema.yml
@@ -1,1 +1,1 @@
-version: 1
+version: 2


### PR DESCRIPTION
# Description
Adding the ability to add custom tests and execute the tests with subprocess.

Things to have in mind:
 - If the test is malformed all the tests that you add can not be checked, and as a result, they will not be added.
 - The process of adding tests is really simple, we add all the tests we execute dbt test in the model, get the response and calculate which model is PASS and which FAIL or ERROR. We remove all the tests that the status is not PASS.
 


# How was the change tested
Ran it in local. 

Closes #65

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
