### PR TITLE
feat: allow audit task to run bootstrap

### DIFF
--- a/changelog/239.feature.md
+++ b/changelog/239.feature.md
@@ -1,0 +1,3 @@
+When running `dbt-sugar audit` users can now trigger all models (as well as their columns) to have at least placeholders in schema.yml files by passing the `--bootstrap` optional argument. This ensures that the audit task is fully aware of all the models before running its checks.
+
+**NOTE:** the `--bootstrap` option will check for all of your models against your database and may be slower but it will give you the most accurate coverage statistics.

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -53,6 +53,7 @@ class FlagParser:
         # task specific args consumption
         if self.task == "audit":
             self.model = self.args.model
+            self.run_bootstrap_first = self.args.bootstrap
         elif self.task == "doc":
             self.model = self.args.model
             self.schema = self.args.schema

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -156,6 +156,16 @@ audit_sub_parser.add_argument(
     default=None,
     required=False,
 )
+audit_sub_parser.add_argument(
+    "--bootstrap",
+    help=(
+        "When passed the audit task will run the bootstrap task "
+        "(which creates placeholders for any undocumented model and columns) first"
+    ),
+    default=False,
+    action="store_true",
+    required=False,
+)
 
 
 # ##### BOOTSTRAP Task Arg parser
@@ -223,10 +233,19 @@ def handle(
             sugar_config=sugar_config,
             dbt_profile=dbt_profile,
         )
+        if flag_parser.run_bootstrap_first:
+            logger.info("Running 'bootstrap' task first then auditing your project or model")
+            bootstrap_task: BootstrapTask = BootstrapTask(
+                flags=flag_parser,
+                dbt_path=dbt_project._project_dir,
+                sugar_config=sugar_config,
+                dbt_profile=dbt_profile,
+            )
+            bootstrap_task.run()
         return audit_task.run()
 
     if flag_parser.task == "bootstrap":
-        bootstrap_task: BootstrapTask = BootstrapTask(
+        bootstrap_task = BootstrapTask(
             flags=flag_parser,
             dbt_path=dbt_project._project_dir,
             sugar_config=sugar_config,


### PR DESCRIPTION
# Description
In #233 we added a new task called `bootstrap` which creates models and column placeholders. Users might want to make the audit task optionally call the bootstrap first which they can now do by calling audit with `--bootstrap`

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information
Resolves #210
(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
