### PR TITLE
fix: sort files when building all models dict

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check for Container
         run: docker ps
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v4
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Tests and Coverage Report
         run: |
-          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/
+          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/ -vv
 
       - name: Upload coverage report to CodeCov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Tests and Coverage Report
         run: |
-          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/ -vv
+          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/ -vv -s
 
       - name: Upload coverage report to CodeCov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Tests and Coverage Report
         run: |
-          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/ -vv -s
+          PYTHONPATH=src/ poetry run python -m pytest --cov-report=xml:coverage-reports/coverage.xml --cov-report term-missing  --cov=dbt_sugar tests/
 
       - name: Upload coverage report to CodeCov
         uses: codecov/codecov-action@v1

--- a/changelog/257.fix.md
+++ b/changelog/257.fix.md
@@ -1,0 +1,1 @@
+Fixes a weird bug in the `bootstrap` task which resulted in unpredictable file ordering and failed only in GitHub Actions. We now sort the files before building the dbt model info dict for the bootstrap task.

--- a/dbt_sugar/core/task/bootstrap.py
+++ b/dbt_sugar/core/task/bootstrap.py
@@ -68,7 +68,7 @@ class BootstrapTask(DocumentationTask):
                             model_path=Path(root, f),
                             model_columns=[],
                         )
-                        for f in files
+                        for f in sorted(files)
                         if f.lower().endswith(".sql")
                         and f.lower().replace(".sql", "")
                         not in self._sugar_config.dbt_project_info.get("excluded_models", [])

--- a/tests/bootstrap_task_test.py
+++ b/tests/bootstrap_task_test.py
@@ -36,6 +36,7 @@ def test_build_all_models_dict(datafiles):
         dbt_profile=profile,
     )
     task.build_all_models_dict()
+    print("BUILT")
     print(task.dbt_models_data)
     expectation = [
         DbtModelsDict(
@@ -53,6 +54,8 @@ def test_build_all_models_dict(datafiles):
             model_columns=[],
         ),
     ]
+    print("EXPT")
+    print(expectation)
     assert task.dbt_models_data == expectation
 
 


### PR DESCRIPTION
# Description
A weird error happened in the CI only in GHAs. It was due to the files list not being sorted. Adding a `sorted()` on the list fixes the issue
 
# How was the change tested
Unit tests are now passing again.

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)

