### PR TITLE
fix: allow run dbt-sugar tests outside the project

### DIFF
--- a/dbt_sugar/core/task/doc.py
+++ b/dbt_sugar/core/task/doc.py
@@ -47,6 +47,7 @@ class DocumentationTask(BaseTask):
         self._flags = flags
         self._dbt_profile = dbt_profile
         self._sugar_config = config
+        self.dbt_path = dbt_path
 
     def run(self) -> int:
         """Main script to run the command doc"""
@@ -315,7 +316,7 @@ class DocumentationTask(BaseTask):
             path_file (Path): Path of the schema.yml file to update.
             model_name (str): Name of the model to document.
         """
-        dbt_command = f"dbt test --models {quote(model_name)}".split()
+        dbt_command = f"dbt test --models {quote(model_name)} --project-dir {self.dbt_path}".split()
         dbt_result_command = subprocess.run(dbt_command, capture_output=True, text=True).stdout
         tests_to_delete: Dict[str, List[str]] = {}
 


### PR DESCRIPTION
# Description
Adding into dbt test the parameter project-dir so we are able to run the tests outside the project.

# How was the change tested
Ran it in local.

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [X] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
