### PR TITLE
feat: make complex tests prompts a bit more user friendly

### DIFF
--- a/changelog/268.misc.md
+++ b/changelog/268.misc.md
@@ -1,0 +1,1 @@
+The test adding prompt is a bit more user-friendly and clear when it comes to asking about whether users want to add complex or simple builtin tests.

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -258,7 +258,6 @@ class UserInputCollector:
                         " those more easily.",
                         choices=["builtin tests", "complex tests"],
                     ).unsafe_ask()
-                    print(wants_to_pop_editor)
                     if "complex tests" in wants_to_pop_editor:
                         tests = self.collect_rich_user_input()
                     else:

--- a/dbt_sugar/core/ui/cli_ui.py
+++ b/dbt_sugar/core/ui/cli_ui.py
@@ -250,11 +250,16 @@ class UserInputCollector:
                     message="Would you like to add any tests?"
                 ).unsafe_ask()
                 if wants_to_add_tests:
-                    wants_to_pop_editor = questionary.confirm(
-                        message="Do you want to add a complex or custom tests? If, so we'll open a test editor for "
-                        f"you, otherwise you can choose from the following builtins: {AVAILABLE_TESTS}"
+                    wants_to_pop_editor = questionary.checkbox(
+                        # message="Do you want to add a complex or custom tests? If, so we'll open a test editor for "
+                        # f"you, otherwise you can choose from the following builtins: {AVAILABLE_TESTS}"
+                        message="Do you want to add simple builtin tests or custom/more complex tests?"
+                        "\nIf you choose 'complex tests' we'll take you to a text editor so you can add"
+                        " those more easily.",
+                        choices=["builtin tests", "complex tests"],
                     ).unsafe_ask()
-                    if wants_to_pop_editor:
+                    print(wants_to_pop_editor)
+                    if "complex tests" in wants_to_pop_editor:
                         tests = self.collect_rich_user_input()
                     else:
                         tests = questionary.checkbox(

--- a/tests/cli_ui_test.py
+++ b/tests/cli_ui_test.py
@@ -212,12 +212,12 @@ def test__document_already_documented_cols(
             {
                 "column_a": {
                     "description": "Dummy description",
-                    "tests": [{"accepted_values": ["a"]}],
+                    "tests": ["unique"],
                     "tags": ["Dummy description"],
                 },
                 "column_b": {
                     "description": "Dummy description",
-                    "tests": [{"accepted_values": ["a"]}],
+                    "tests": ["unique"],
                     "tags": ["Dummy description"],
                 },
             },


### PR DESCRIPTION
# Description
The test prompt asking users whether they want to add complex or simple test was a bit confusing it is not (hopefully) less confusing

# How was the change tested

(If you have implemented unit tests you can list them and give some context on what they cover. If you did not implement unit testing or the change is harder to test, tell us how you made sure your change worked so we can reproduce it and check that all the bases are covered)

# Issue Information

(If your PR addresses or closes a GitHub issue please write "Closes #<issue_number>" or something like that).

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
