### PR TITLE
fix: add default sslmode to redshift connector engine

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,8 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "[BUG]"
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
@@ -12,6 +11,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behaviour:
+
 1. Run command "..."
 2. etc.
 
@@ -19,18 +19,20 @@ Steps to reproduce the behaviour:
 A clear and concise description of what you expected to happen.
 
 **Console Log/Tracebacks**
-Please avoid screenshots if possible, instead copy and paste the console and wrap it in 
-``` code  by using ```code block``` ``` 
+Please avoid screenshots if possible, instead copy and paste the console and wrap it in
+`code by using`code block` `
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,10 +1,9 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/changelog/changelog/291.fix.md
+++ b/changelog/changelog/291.fix.md
@@ -1,1 +1,3 @@
 The redshift_connector now includes the default `sslmode=prefer` parameter in the engine when creating a connection. This fixes an issue when Redshift connections are made via SSH.
+
+by @danieldiamond

--- a/changelog/changelog/291.fix.md
+++ b/changelog/changelog/291.fix.md
@@ -1,0 +1,1 @@
+The redshift_connector now includes the default `sslmode=prefer` parameter in the engine when creating a connection. This fixes an issue when Redshift connections are made via SSH.

--- a/dbt_sugar/core/connectors/redshift_connector.py
+++ b/dbt_sugar/core/connectors/redshift_connector.py
@@ -36,4 +36,6 @@ class RedshiftConnector(BaseConnector):
             database=connection_params.get("database", str()),
             port=connection_params.get("port", str()),
         )
-        self.engine = sqlalchemy.create_engine(self.connection_url, connect_args={'sslmode': 'prefer'})
+        self.engine = sqlalchemy.create_engine(
+            self.connection_url, connect_args={"sslmode": "prefer"}
+        )

--- a/dbt_sugar/core/connectors/redshift_connector.py
+++ b/dbt_sugar/core/connectors/redshift_connector.py
@@ -36,4 +36,4 @@ class RedshiftConnector(BaseConnector):
             database=connection_params.get("database", str()),
             port=connection_params.get("port", str()),
         )
-        self.engine = sqlalchemy.create_engine(self.connection_url)
+        self.engine = sqlalchemy.create_engine(self.connection_url, connect_args={'sslmode': 'prefer'})


### PR DESCRIPTION
# Description
Unable to connect to Redshift warehouse via autossh
```
(psycopg2.OperationalError) server certificate for "..redshift.amazonaws.com" does not match host name "localhost"
```
Adding the default `sslmode` per `psycopg2` [docs on SSL Connections](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/dialects/postgresql/psycopg2.py#L77)


# How was the change tested

I was able to test that this change allowed my `localhost` connection to Redshift to work. However, I cannot test if this will break other Redshift connector configurations.

# Issue Information

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
