### PR TITLE
fix: do not save yamls that do not contain models

### DIFF
--- a/changelog/309.fix.md
+++ b/changelog/309.fix.md
@@ -1,0 +1,1 @@
+dbt-sugar now stops messing with `.yaml` files that are not model descriptor files. When we are about to save a yaml file that we have processed for some reason, we will just not save it. An under the hood revisit will address this issue in a more long-term and economical way. Resolves #294, reported by [@diegodewilde](https://github.com/diegodewilde)

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -151,7 +151,6 @@ document_sub_parser.add_argument(
         "will not be sanitised in any way such as alphabetically sorted."
     ),
     action="store_true",
-    # default=False,
 )
 
 # ##### AUDIT Task

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -389,7 +389,8 @@ class BaseTask(abc.ABC):
                         ),
                     )
                     logger.debug(path_file)
-                    self.load_descriptions_from_a_schema_file(content, path_file)
+                    if content.get("models"):
+                        self.load_descriptions_from_a_schema_file(content, path_file)
 
     def is_model_in_schema_content(self, content, model_name) -> bool:
         """Method to check if a model exists in a schema.yaml content.


### PR DESCRIPTION
# Description
When we walk through yaml files, we basically process any kind of yaml unless they are in some folder exclusion that we know of or because users have specified to exclude some models from the dbt-sugar scope.

However, when we don't know we have to exclude the files we process it and we end up potentially changing its format and maybe even content?

This is kind of a "hot-fix" PR to get the feature out to a user in need, but we will want to overhaul the way we walk through and into files so that we don't end up processing a bunch of useless crap.

# How was the change tested
Tested locally, with random yaml file within the dbt model scope and working fine.

# Issue Information

Resolves #294

# Checklist

(Ideally, all boxes are checked by the time we merged the PR, if you don't know how to do any of these don't hesitate to say so in the PR and we'll help you out.)

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
