### PR TITLE
fix: Profile target available to ALL commands

### DIFF
--- a/changelog/348.fix.md
+++ b/changelog/348.fix.md
@@ -1,0 +1,3 @@
+Moved profile target CLI arg to base subparser such that it is available in all commands. This means other
+commands are no longer forced into the default target.
+by [@z3z1ma](https://github.com/z3z1ma)

--- a/dbt_sugar/core/flags.py
+++ b/dbt_sugar/core/flags.py
@@ -45,6 +45,7 @@ class FlagParser:
             self.log_level = self.args.log_level
             self.verbose = self.args.verbose
             self.syrup = self.args.syrup
+            self.target = self.args.target
             if self.args.profiles_dir:
                 self.profiles_dir = Path(self.args.profiles_dir).expanduser()
             if self.args.config_path:
@@ -61,7 +62,6 @@ class FlagParser:
             self.model = self.args.model
             self.schema = self.args.schema
             self.is_dry_run = self.args.dry_run
-            self.target = self.args.target
             # we reverse the flag so that we don't have double negatives later in the code
             self.ask_for_tests = self.args.ask_for_tests
             self.ask_for_tags = self.args.ask_for_tags

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -43,9 +43,7 @@ parser = argparse.ArgumentParser(
     epilog="Select one of the available sub-commands with --help to find out more about them.",
 )
 
-parser.add_argument(
-    "-v", "--version", action="version", version=check_and_print_version()
-)
+parser.add_argument("-v", "--version", action="version", version=check_and_print_version())
 
 # base sub-parser (sets up args that need to be provided to ALL other sub parsers)
 base_subparser = argparse.ArgumentParser(add_help=False)
@@ -80,9 +78,7 @@ base_subparser.add_argument(
 )
 
 # Task-specific argument sub parsers
-sub_parsers = parser.add_subparsers(
-    title="Available dbt-sugar commands", dest="command"
-)
+sub_parsers = parser.add_subparsers(title="Available dbt-sugar commands", dest="command")
 
 # DOC task parser
 document_sub_parser = sub_parsers.add_parser(
@@ -264,18 +260,14 @@ def handle(
         # dry run but for now this allows testing without side effects.
         # the current implementation upsets mypy also.
         if flag_parser.is_dry_run:
-            logger.warning(
-                "[yellow]Running in --dry-run mode no files will be modified"
-            )
+            logger.warning("[yellow]Running in --dry-run mode no files will be modified")
             logger.info(f"Would run {task}")
             return 0
         return task.run()
 
     if flag_parser.task == "audit":
         if flag_parser.run_bootstrap_first:
-            logger.info(
-                "Running 'bootstrap' task first then auditing your project or model"
-            )
+            logger.info("Running 'bootstrap' task first then auditing your project or model")
             bootstrap_task: BootstrapTask = BootstrapTask(
                 flags=flag_parser,
                 dbt_path=dbt_project._project_dir,
@@ -303,9 +295,7 @@ def handle(
     raise NotImplementedError(f"{flag_parser.task} is not supported.")
 
 
-def main(
-    parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()
-) -> int:
+def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()) -> int:
     """Just your boring main."""
     exit_code = 0
     _cli_args = test_cli_args or []

--- a/dbt_sugar/core/main.py
+++ b/dbt_sugar/core/main.py
@@ -40,10 +40,12 @@ parser = argparse.ArgumentParser(
     prog="dbt-sugar",
     formatter_class=argparse.RawTextHelpFormatter,
     description="CLI tool to help users document their dbt models",
-    epilog="Select onf of the available sub-commands with --help to find out more about them.",
+    epilog="Select one of the available sub-commands with --help to find out more about them.",
 )
 
-parser.add_argument("-v", "--version", action="version", version=check_and_print_version())
+parser.add_argument(
+    "-v", "--version", action="version", version=check_and_print_version()
+)
 
 # base sub-parser (sets up args that need to be provided to ALL other sub parsers)
 base_subparser = argparse.ArgumentParser(add_help=False)
@@ -69,9 +71,18 @@ base_subparser.add_argument(
 base_subparser.add_argument(
     "--profiles-dir", help="Alternative path to the dbt profiles.yml file.", type=str
 )
+base_subparser.add_argument(
+    "-t",
+    "--target",
+    help="Which target from the dbt profile to load.",
+    type=str,
+    default=str(),
+)
 
 # Task-specific argument sub parsers
-sub_parsers = parser.add_subparsers(title="Available dbt-sugar commands", dest="command")
+sub_parsers = parser.add_subparsers(
+    title="Available dbt-sugar commands", dest="command"
+)
 
 # DOC task parser
 document_sub_parser = sub_parsers.add_parser(
@@ -80,7 +91,12 @@ document_sub_parser = sub_parsers.add_parser(
 document_sub_parser.set_defaults(cls=DocumentationTask, which="doc")
 # TODO: We shouldn't be requiring this if we have a `--model` format as it's considered bad practice
 document_sub_parser.add_argument(
-    "-m", "--model", help="Name of the dbt model to document", type=str, default=None, required=True
+    "-m",
+    "--model",
+    help="Name of the dbt model to document",
+    type=str,
+    default=None,
+    required=True,
 )
 document_sub_parser.add_argument(
     "-s",
@@ -94,13 +110,6 @@ document_sub_parser.add_argument(
     help="When provided the documentation task will not modify your files",
     action="store_true",
     default=False,
-)
-document_sub_parser.add_argument(
-    "-t",
-    "--target",
-    help="Which target from the dbt profile to load.",
-    type=str,
-    default=str(),
 )
 
 document_sub_parser.add_argument(
@@ -255,14 +264,18 @@ def handle(
         # dry run but for now this allows testing without side effects.
         # the current implementation upsets mypy also.
         if flag_parser.is_dry_run:
-            logger.warning("[yellow]Running in --dry-run mode no files will be modified")
+            logger.warning(
+                "[yellow]Running in --dry-run mode no files will be modified"
+            )
             logger.info(f"Would run {task}")
             return 0
         return task.run()
 
     if flag_parser.task == "audit":
         if flag_parser.run_bootstrap_first:
-            logger.info("Running 'bootstrap' task first then auditing your project or model")
+            logger.info(
+                "Running 'bootstrap' task first then auditing your project or model"
+            )
             bootstrap_task: BootstrapTask = BootstrapTask(
                 flags=flag_parser,
                 dbt_path=dbt_project._project_dir,
@@ -290,7 +303,9 @@ def handle(
     raise NotImplementedError(f"{flag_parser.task} is not supported.")
 
 
-def main(parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()) -> int:
+def main(
+    parser: argparse.ArgumentParser = parser, test_cli_args: List[str] = list()
+) -> int:
     """Just your boring main."""
     exit_code = 0
     _cli_args = test_cli_args or []

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -49,9 +49,7 @@ class BaseTask(abc.ABC):
         self.dbt_tests: Dict[str, List[Dict[str, Any]]] = {}
         self.build_descriptions_dictionary()
 
-    def get_connector(
-        self,
-    ) -> Union[PostgresConnector, SnowflakeConnector, RedshiftConnector]:
+    def get_connector(self) -> Union[PostgresConnector, SnowflakeConnector, RedshiftConnector]:
         dbt_credentials = self._dbt_profile.profile
         connector = DB_CONNECTORS.get(dbt_credentials.get("type", ""))
         if not connector:
@@ -215,9 +213,7 @@ class BaseTask(abc.ABC):
         )
 
     def update_column_description_from_schema(
-        self,
-        path_file: Path,
-        dict_column_description_to_update: Dict[str, Dict[str, Any]],
+        self, path_file: Path, dict_column_description_to_update: Dict[str, Dict[str, Any]]
     ) -> None:
         """Method to update a schema.yml with a Dict of columns names and description.
 
@@ -436,11 +432,7 @@ class BaseTask(abc.ABC):
                         schema_file_exists = False
                         if schema_file_path.exists():
                             schema_file_exists = True
-                        return (
-                            schema_file_path,
-                            schema_file_exists,
-                            is_already_documented,
-                        )
+                        return (schema_file_path, schema_file_exists, is_already_documented)
 
                     if schema_file_path and model_file_found:
                         logger.debug(
@@ -448,11 +440,7 @@ class BaseTask(abc.ABC):
                         )
                         is_already_documented = True
                         schema_file_exists = True
-                        return (
-                            schema_file_path,
-                            schema_file_exists,
-                            is_already_documented,
-                        )
+                        return (schema_file_path, schema_file_exists, is_already_documented)
         return None, False, False
 
     def is_exluded_model(self, model_name: str) -> bool:

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -99,10 +99,7 @@ class BaseTask(abc.ABC):
         for model in schema_content.get("models", []):
             if model["name"] == model_name:
                 for column in model.get("columns", []):
-                    if (
-                        column.get("description", COLUMN_NOT_DOCUMENTED)
-                        != COLUMN_NOT_DOCUMENTED
-                    ):
+                    if column.get("description", COLUMN_NOT_DOCUMENTED) != COLUMN_NOT_DOCUMENTED:
                         documented_columns[column["name"]] = column["description"]
         return documented_columns
 
@@ -144,16 +141,11 @@ class BaseTask(abc.ABC):
         for model in schema_content.get("models", []):
             if model["name"] == model_name:
                 for column in model.get("columns", []):
-                    if (
-                        column.get("description", COLUMN_NOT_DOCUMENTED)
-                        == COLUMN_NOT_DOCUMENTED
-                    ):
+                    if column.get("description", COLUMN_NOT_DOCUMENTED) == COLUMN_NOT_DOCUMENTED:
                         not_documented_columns[column["name"]] = COLUMN_NOT_DOCUMENTED
         return not_documented_columns
 
-    def combine_two_list_without_duplicates(
-        self, list1: List[Any], list2: List[Any]
-    ) -> List[Any]:
+    def combine_two_list_without_duplicates(self, list1: List[Any], list2: List[Any]) -> List[Any]:
         """
         Method to combine two list without duplicates.
 
@@ -189,9 +181,7 @@ class BaseTask(abc.ABC):
         """
         content = open_yaml(
             path_file,
-            preserve_yaml_order=self._sugar_config.config.get(
-                "preserve_yaml_order", False
-            ),
+            preserve_yaml_order=self._sugar_config.config.get("preserve_yaml_order", False),
         )
         for model in content.get("models", []):
             if model["name"] == model_name:
@@ -199,25 +189,21 @@ class BaseTask(abc.ABC):
                     column_name = column["name"]
                     if column_name in dict_column_description_to_update:
                         # Update the description
-                        description = dict_column_description_to_update[
-                            column_name
-                        ].get("description")
+                        description = dict_column_description_to_update[column_name].get(
+                            "description"
+                        )
                         if description:
                             column["description"] = description
 
                         # Update the tests without duplicating them.
-                        tests = dict_column_description_to_update[column_name].get(
-                            "tests"
-                        )
+                        tests = dict_column_description_to_update[column_name].get("tests")
                         if tests:
                             column["tests"] = self.combine_two_list_without_duplicates(
                                 column.get("tests", []), tests
                             )
 
                         # Update the tags without duplicating them.
-                        tags = dict_column_description_to_update[column_name].get(
-                            "tags"
-                        )
+                        tags = dict_column_description_to_update[column_name].get("tags")
                         if tags:
                             column["tags"] = self.combine_two_list_without_duplicates(
                                 column.get("tags", []), tags
@@ -225,9 +211,7 @@ class BaseTask(abc.ABC):
         save_yaml(
             path_file,
             content,
-            preserve_yaml_order=self._sugar_config.config.get(
-                "preserve_yaml_order", False
-            ),
+            preserve_yaml_order=self._sugar_config.config.get("preserve_yaml_order", False),
         )
 
     def update_column_description_from_schema(
@@ -244,25 +228,21 @@ class BaseTask(abc.ABC):
         """
         content = open_yaml(
             path_file,
-            preserve_yaml_order=self._sugar_config.config.get(
-                "preserve_yaml_order", False
-            ),
+            preserve_yaml_order=self._sugar_config.config.get("preserve_yaml_order", False),
         )
         for model in content.get("models", []):
             for column in model.get("columns", []):
                 column_name = column["name"]
                 if column_name in dict_column_description_to_update:
-                    new_description = dict_column_description_to_update[
-                        column_name
-                    ].get("description")
+                    new_description = dict_column_description_to_update[column_name].get(
+                        "description"
+                    )
                     if new_description:
                         column["description"] = new_description
         save_yaml(
             path_file,
             content,
-            preserve_yaml_order=self._sugar_config.config.get(
-                "preserve_yaml_order", False
-            ),
+            preserve_yaml_order=self._sugar_config.config.get("preserve_yaml_order", False),
         )
 
     def update_column_descriptions(
@@ -317,9 +297,7 @@ class BaseTask(abc.ABC):
             column_description = COLUMN_NOT_DOCUMENTED
         self.dbt_definitions[column_name] = column_description
 
-    def remove_excluded_models(
-        self, content: Dict[str, Any]
-    ) -> Optional[List[Dict[str, Any]]]:
+    def remove_excluded_models(self, content: Dict[str, Any]) -> Optional[List[Dict[str, Any]]]:
         """Removes models that are excluded_models from the models dict"""
         models = content.get("models", [])
         # if self._sugar_config.dbt_project_info.get("excluded_models"):
@@ -328,8 +306,7 @@ class BaseTask(abc.ABC):
             return [
                 model_dict
                 for model_dict in models
-                if model_dict["name"]
-                not in self._sugar_config.dbt_project_info["excluded_models"]
+                if model_dict["name"] not in self._sugar_config.dbt_project_info["excluded_models"]
             ]
 
         return None
@@ -370,9 +347,7 @@ class BaseTask(abc.ABC):
             self.all_dbt_models[model["name"]] = path_schema
             for column in model.get("columns", []):
                 column_description = column.get("description", None)
-                self.update_description_in_dbt_descriptions(
-                    column["name"], column_description
-                )
+                self.update_description_in_dbt_descriptions(column["name"], column_description)
                 self.update_test_in_dbt_tests(model["name"], column)
 
     def get_file_path_from_sql_model(self, model_name: str) -> Optional[Path]:
@@ -436,9 +411,7 @@ class BaseTask(abc.ABC):
 
         return any(model["name"] == model_name for model in content.get("models", []))
 
-    def find_model_schema_file(
-        self, model_name: str
-    ) -> Tuple[Optional[Path], bool, bool]:
+    def find_model_schema_file(self, model_name: str) -> Tuple[Optional[Path], bool, bool]:
         for root, _, files in os.walk(self.repository_path):
             if not re.search(self._excluded_folders_from_search_pattern, root):
                 schema_file_path = None

--- a/dbt_sugar/core/task/base.py
+++ b/dbt_sugar/core/task/base.py
@@ -42,7 +42,7 @@ class BaseTask(abc.ABC):
         self._flags = flags
         self._dbt_profile = dbt_profile
 
-        # populated by class methods
+        # Populated by class methods
         self._excluded_folders_from_search_pattern: str = self.setup_paths_exclusion()
         self.all_dbt_models: Dict[str, Path] = {}
         self.dbt_definitions: Dict[str, str] = {}
@@ -444,7 +444,7 @@ class BaseTask(abc.ABC):
 
                     if schema_file_path and model_file_found:
                         logger.debug(
-                            f"'{model_name}' found in '{schema_file_path}' we'll update entry."
+                            f"'{model_name}' found in '{schema_file_path}', we'll update entry."
                         )
                         is_already_documented = True
                         schema_file_exists = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,6 @@ title_format = "## dbt-sugar [{version}] - {project_date}"
 
 [tool.pytest.ini_options]
 markers = ["datafiles"]
+
+[tool.black]
+line-length = 100


### PR DESCRIPTION
# Description

This solves for profile target not being available in all commands and defaulting to the default profile. 

# How was the change tested

I personally ran it on my own dbt projects. 

# Issue Information

Relevant issue #346 

# Checklist

- [x] I formatted my PR name according to [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] I added a news fragment to help populating the changelog as encouraged in [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] I added "Closes #<issue_number>" in the "Issue Information" section (if no issue, feel free to tick thick the box anyway).
